### PR TITLE
feat(arch): add arch/ plugin system with Cortex-M implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,12 +65,15 @@ add_executable(mkdbg-native
   src/seam.c
   src/dashboard.c
   src/wire.c
+  arch/cortex_m.c
+  arch/arch_registry.c
   $<TARGET_OBJECTS:seam_lib>
   $<TARGET_OBJECTS:wire_crash_lib>
 )
 target_compile_options(mkdbg-native PRIVATE -Wall -Wextra -Werror -O2)
 target_include_directories(mkdbg-native PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/host
+  ${CMAKE_CURRENT_LIST_DIR}/src
+  ${CMAKE_CURRENT_LIST_DIR}/arch
   ${CMAKE_CURRENT_LIST_DIR}/deps/seam/include
   ${CMAKE_CURRENT_LIST_DIR}/deps/wire/include
   ${CMAKE_CURRENT_LIST_DIR}/deps/wire/host
@@ -128,3 +131,16 @@ add_test(
 set_tests_properties(seam_analyze_kdi_cascade PROPERTIES
   PASS_REGULAR_EXPRESSION "VERDICT:"
 )
+
+# ── ctest: arch plugin registry ───────────────────────────────────────────────
+add_executable(arch_test
+  tests/arch_test.c
+  arch/cortex_m.c
+  arch/arch_registry.c
+)
+target_compile_options(arch_test PRIVATE -Wall -Wextra -Werror -O2)
+target_include_directories(arch_test PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/src
+  ${CMAKE_CURRENT_LIST_DIR}/arch
+)
+add_test(NAME arch_registry COMMAND arch_test)

--- a/arch/arch.h
+++ b/arch/arch.h
@@ -1,0 +1,40 @@
+/* arch/arch.h — MkdbgArch plugin interface
+ *
+ * Each supported MCU architecture is registered as a MkdbgArch entry in
+ * arch_registry.c.  mkdbg selects the active arch via --arch <name>.
+ *
+ * To add a new architecture:
+ *   1. Create arch/your_arch.c with a static decode_crash function.
+ *   2. Define  const MkdbgArch your_arch_arch = { .name = "your-arch", ... };
+ *   3. Add &your_arch_arch to the arches[] array in arch_registry.c.
+ *   4. Add your_arch.c to the mkdbg-native source list in CMakeLists.txt.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "mkdbg.h"   /* WireCrashReport, WIRE_* constants */
+
+/* MkdbgCrashReport aliases WireCrashReport for the arch layer. */
+typedef WireCrashReport MkdbgCrashReport;
+
+typedef struct {
+    const char *name;  /* arch name matched by --arch flag, e.g. "cortex-m" */
+
+    /*
+     * Decode a raw crash payload into *out.
+     *
+     * raw: arch-defined binary blob (each implementation documents its format)
+     * len: byte count of raw
+     * out: pre-zeroed output struct; caller owns lifetime
+     *
+     * Returns 0 on success, -1 on error (bad length, parse failure, etc.).
+     */
+    int (*decode_crash)(const uint8_t *raw, size_t len, MkdbgCrashReport *out);
+} MkdbgArch;
+
+/* Returns the registered arch whose name matches (case-sensitive), or NULL. */
+const MkdbgArch *mkdbg_arch_find(const char *name);

--- a/arch/arch_registry.c
+++ b/arch/arch_registry.c
@@ -1,0 +1,27 @@
+/* arch/arch_registry.c — static registry of built-in MkdbgArch implementations
+ *
+ * To register a new arch: declare it extern here and add a pointer to arches[].
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "arch.h"
+
+#include <string.h>
+
+extern const MkdbgArch cortex_m_arch;
+
+static const MkdbgArch *arches[] = {
+    &cortex_m_arch,
+    NULL,
+};
+
+const MkdbgArch *mkdbg_arch_find(const char *name)
+{
+    if (!name) return NULL;
+    for (int i = 0; arches[i]; i++) {
+        if (strcmp(arches[i]->name, name) == 0)
+            return arches[i];
+    }
+    return NULL;
+}

--- a/arch/cortex_m.c
+++ b/arch/cortex_m.c
@@ -1,0 +1,259 @@
+/* arch/cortex_m.c — Cortex-M crash decoder
+ *
+ * Extracted from deps/wire/host/wire_crash.c.  All functions in this file
+ * are pure: no I/O, no UART, no RSP protocol — only data transformations.
+ *
+ * Raw crash payload format (little-endian):
+ *   bytes  [0..3]   halt_signal    (uint32_t)
+ *   bytes  [4..71]  registers[17]  (17 × uint32_t, r0–r12 sp lr pc xpsr)
+ *   bytes [72..75]  cfsr           (uint32_t)
+ *   bytes [76..]    stack_bytes    (optional; for heuristic backtrace)
+ *
+ * Minimum payload: 76 bytes.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "arch.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ── hex helpers ─────────────────────────────────────────────────────────── */
+
+static int hex2(const char *s)
+{
+    int hi = 0, lo = 0;
+    if      (s[0] >= '0' && s[0] <= '9') hi = s[0] - '0';
+    else if (s[0] >= 'a' && s[0] <= 'f') hi = s[0] - 'a' + 10;
+    else if (s[0] >= 'A' && s[0] <= 'F') hi = s[0] - 'A' + 10;
+    else return -1;
+    if      (s[1] >= '0' && s[1] <= '9') lo = s[1] - '0';
+    else if (s[1] >= 'a' && s[1] <= 'f') lo = s[1] - 'a' + 10;
+    else if (s[1] >= 'A' && s[1] <= 'F') lo = s[1] - 'A' + 10;
+    else return -1;
+    return (hi << 4) | lo;
+}
+
+/* Parse 8 hex chars in little-endian byte order into uint32_t. */
+static int parse_le32(const char *hex8, uint32_t *out)
+{
+    uint32_t val = 0;
+    for (int b = 0; b < 4; b++) {
+        int byte = hex2(hex8 + b * 2);
+        if (byte < 0) return -1;
+        val |= (uint32_t)((unsigned)byte << (b * 8));
+    }
+    *out = val;
+    return 0;
+}
+
+/* ── halt signal ─────────────────────────────────────────────────────────── */
+
+static const char *signal_name(int sig)
+{
+    switch (sig) {
+    case 1:  return "SIGHUP";
+    case 2:  return "SIGINT";
+    case 5:  return "SIGTRAP";
+    case 6:  return "SIGABRT";
+    case 7:  return "SIGBUS";
+    case 8:  return "SIGFPE";
+    case 11: return "SIGSEGV";
+    case 15: return "SIGTERM";
+    default: return "UNKNOWN";
+    }
+}
+
+/*
+ * Parse halt response: S<2hex> or T<2hex>...
+ * Returns signal number, or -1 on parse error.
+ */
+static int parse_halt_signal(const char *resp)
+{
+    if ((resp[0] == 'S' || resp[0] == 'T') && resp[1] && resp[2]) {
+        int s = hex2(resp + 1);
+        if (s >= 0) return s;
+    }
+    return -1;
+}
+
+/* ── registers ───────────────────────────────────────────────────────────── */
+
+/*
+ * Cortex-M GDB register order:
+ *   r0–r12 (0–12), sp/r13 (13), lr/r14 (14), pc/r15 (15), xpsr (16)
+ * Each register: 4 bytes = 8 hex chars, little-endian.
+ * Total: 17 * 8 = 136 hex chars.
+ */
+#define CM_NREGS 17
+static const char *reg_names[CM_NREGS] = {
+    "r0","r1","r2","r3","r4","r5","r6","r7",
+    "r8","r9","r10","r11","r12","sp","lr","pc","xpsr"
+};
+
+static int parse_registers(const char *resp, uint32_t regs[CM_NREGS])
+{
+    if (strlen(resp) < CM_NREGS * 8u) return -1;
+    for (int i = 0; i < CM_NREGS; i++) {
+        if (parse_le32(resp + i * 8, &regs[i]) != 0) return -1;
+    }
+    return 0;
+}
+
+/* ── CFSR decode ─────────────────────────────────────────────────────────── */
+
+typedef struct {
+    uint32_t    bit;
+    const char *name;
+    const char *desc;
+} CfsrBit;
+
+static const CfsrBit cfsr_bits[] = {
+    /* MemManage fault (bits 0–7) */
+    { 1u << 0,  "IACCVIOL",    "instruction access MPU violation" },
+    { 1u << 1,  "DACCVIOL",    "data access MPU violation" },
+    { 1u << 3,  "MUNSTKERR",   "MemManage fault on unstacking" },
+    { 1u << 4,  "MSTKERR",     "MemManage fault on stacking" },
+    { 1u << 5,  "MLSPERR",     "MemManage fault on lazy FP save" },
+    /* BusFault (bits 8–15) */
+    { 1u << 8,  "IBUSERR",     "instruction bus error" },
+    { 1u << 9,  "PRECISERR",   "precise data bus error" },
+    { 1u << 10, "IMPRECISERR", "imprecise data bus error" },
+    { 1u << 11, "UNSTKERR",    "bus fault on unstacking" },
+    { 1u << 12, "STKERR",      "bus fault on stacking" },
+    { 1u << 13, "LSPERR",      "bus fault on lazy FP save" },
+    /* UsageFault (bits 16–31) */
+    { 1u << 16, "UNDEFINSTR",  "undefined instruction" },
+    { 1u << 17, "INVSTATE",    "invalid execution state (EPSR)" },
+    { 1u << 18, "INVPC",       "integrity check violation on EXC_RETURN" },
+    { 1u << 19, "NOCP",        "coprocessor not available" },
+    { 1u << 24, "UNALIGNED",   "unaligned memory access" },
+    { 1u << 25, "DIVBYZERO",   "divide by zero" },
+};
+#define CFSR_NBITS ((int)(sizeof(cfsr_bits) / sizeof(cfsr_bits[0])))
+
+/* Build a human-readable string into out (capacity out_size). */
+static void cfsr_decode(uint32_t cfsr, char *out, size_t out_size)
+{
+    if (out_size == 0) return;
+    out[0] = '\0';
+    if (cfsr == 0) {
+        snprintf(out, out_size, "no fault bits set");
+        return;
+    }
+    size_t pos = 0;
+    int    first = 1;
+    for (int i = 0; i < CFSR_NBITS; i++) {
+        if (!(cfsr & cfsr_bits[i].bit)) continue;
+        int n = snprintf(out + pos, out_size - pos,
+                         "%s%s — %s",
+                         first ? "" : "; ",
+                         cfsr_bits[i].name,
+                         cfsr_bits[i].desc);
+        if (n < 0 || (size_t)n >= out_size - pos) break;
+        pos  += (size_t)n;
+        first = 0;
+    }
+}
+
+/* ── heuristic backtrace ─────────────────────────────────────────────────── */
+
+/*
+ * Scan stack_bytes for Thumb return addresses in STM32 flash range.
+ * Criteria: word-aligned in buffer, value in 0x08000001–0x08FFFFFF, bit0=1.
+ * Collect up to max_frames frames in frames[]; returns count.
+ */
+static int heuristic_backtrace(const uint8_t *stack_bytes, int stack_len,
+                                uint32_t *frames, int max_frames)
+{
+    int count = 0;
+    for (int off = 0; off + 3 < stack_len && count < max_frames; off += 4) {
+        uint32_t val = (uint32_t)stack_bytes[off]
+                     | ((uint32_t)stack_bytes[off+1] << 8)
+                     | ((uint32_t)stack_bytes[off+2] << 16)
+                     | ((uint32_t)stack_bytes[off+3] << 24);
+        /* Thumb bit set, flash range, not the very base address */
+        if ((val & 1u) && val >= 0x08000001u && val <= 0x08FFFFFFu)
+            frames[count++] = val;
+    }
+    return count;
+}
+
+/* ── decode_crash implementation ─────────────────────────────────────────── */
+
+/*
+ * Raw payload layout (all values little-endian):
+ *   [0..3]   halt_signal  (uint32_t)
+ *   [4..71]  registers    (17 × uint32_t: r0–r12, sp, lr, pc, xpsr)
+ *   [72..75] cfsr         (uint32_t)
+ *   [76..]   stack_bytes  (optional; used for heuristic backtrace)
+ */
+#define CM_RAW_HEADER_LEN 76  /* minimum payload without stack bytes */
+
+static uint32_t le32_load(const uint8_t *p)
+{
+    return (uint32_t)p[0]
+         | ((uint32_t)p[1] << 8)
+         | ((uint32_t)p[2] << 16)
+         | ((uint32_t)p[3] << 24);
+}
+
+static int cortex_m_decode_crash(const uint8_t *raw, size_t len,
+                                  MkdbgCrashReport *out)
+{
+    if (!raw || len < CM_RAW_HEADER_LEN || !out) return -1;
+
+    /* halt signal */
+    uint32_t sig_val = le32_load(raw + 0);
+    out->halt_signal = (int)sig_val;
+    out->timeout     = (sig_val == 0) ? 1 : 0;
+
+    /* registers */
+    for (int i = 0; i < CM_NREGS; i++) {
+        uint32_t rv = le32_load(raw + 4 + i * 4);
+        snprintf(out->regs[i], sizeof(out->regs[i]), "0x%08x", rv);
+    }
+
+    /* CFSR */
+    uint32_t cfsr_val = le32_load(raw + 72);
+    snprintf(out->cfsr, sizeof(out->cfsr), "0x%08x", cfsr_val);
+    cfsr_decode(cfsr_val, out->cfsr_decoded, sizeof(out->cfsr_decoded));
+
+    /* heuristic backtrace from optional stack bytes */
+    if (len > CM_RAW_HEADER_LEN) {
+        const uint8_t *stack_bytes = raw + CM_RAW_HEADER_LEN;
+        int stack_len = (int)(len - CM_RAW_HEADER_LEN);
+        uint32_t frames[WIRE_MAX_FRAMES];
+        int nframes = heuristic_backtrace(stack_bytes, stack_len,
+                                           frames, WIRE_MAX_FRAMES);
+        out->nframes = nframes;
+        for (int i = 0; i < nframes; i++) {
+            snprintf(out->stack_frames[i], sizeof(out->stack_frames[i]),
+                     "0x%08x", frames[i]);
+        }
+    }
+
+    return 0;
+}
+
+/* ── exported arch descriptor ────────────────────────────────────────────── */
+
+const MkdbgArch cortex_m_arch = {
+    .name         = "cortex-m",
+    .decode_crash = cortex_m_decode_crash,
+};
+
+/* suppress "unused function" warnings for parse_registers / parse_halt_signal
+ * / signal_name which are available for callers but not used in this file */
+static void _cortex_m_unused(void) __attribute__((unused));
+static void _cortex_m_unused(void)
+{
+    (void)parse_halt_signal;
+    (void)signal_name;
+    (void)parse_registers;
+    (void)reg_names;
+    (void)hex2;
+}

--- a/tests/arch_test.c
+++ b/tests/arch_test.c
@@ -1,0 +1,65 @@
+/* tests/arch_test.c — arch plugin registry smoke tests
+ *
+ * Verifies that mkdbg_arch_find() returns the expected result for registered
+ * and unknown architecture names.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "arch.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+
+#define CHECK(cond, label) do { \
+    tests_run++; \
+    if (cond) { \
+        tests_passed++; \
+        printf("  PASS  %s\n", label); \
+    } else { \
+        printf("  FAIL  %s\n", label); \
+    } \
+} while (0)
+
+int main(void)
+{
+    printf("arch_test\n");
+
+    /* Known arch must be found */
+    const MkdbgArch *cm = mkdbg_arch_find("cortex-m");
+    CHECK(cm != NULL, "mkdbg_arch_find(\"cortex-m\") != NULL");
+    CHECK(cm != NULL && strcmp(cm->name, "cortex-m") == 0,
+          "arch->name == \"cortex-m\"");
+    CHECK(cm != NULL && cm->decode_crash != NULL,
+          "arch->decode_crash is set");
+
+    /* Unknown arch must return NULL */
+    CHECK(mkdbg_arch_find("unknown") == NULL,
+          "mkdbg_arch_find(\"unknown\") == NULL");
+    CHECK(mkdbg_arch_find("esp32") == NULL,
+          "mkdbg_arch_find(\"esp32\") == NULL");
+    CHECK(mkdbg_arch_find(NULL) == NULL,
+          "mkdbg_arch_find(NULL) == NULL");
+
+    /* decode_crash: reject undersized payload */
+    if (cm && cm->decode_crash) {
+        MkdbgCrashReport report;
+        memset(&report, 0, sizeof(report));
+        int rc = cm->decode_crash(NULL, 0, &report);
+        CHECK(rc == -1, "decode_crash(NULL, 0) returns -1");
+
+        /* Minimal valid payload: 76 bytes of zeros (signal=0 → timeout) */
+        unsigned char raw[76];
+        memset(raw, 0, sizeof(raw));
+        rc = cm->decode_crash(raw, sizeof(raw), &report);
+        CHECK(rc == 0, "decode_crash(zeros, 76) returns 0");
+        CHECK(report.timeout == 1,
+              "zero payload: timeout flag set (halt_signal=0)");
+    }
+
+    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
Introduce the MkdbgArch plugin interface (arch/arch.h) so future MCU architectures (ESP32, RISC-V, etc.) can be added without touching core host-tool code.

- arch/arch.h: MkdbgArch struct {name, decode_crash}, mkdbg_arch_find()
- arch/cortex_m.c: pure Cortex-M decoder extracted from wire_crash.c (cfsr_decode, heuristic_backtrace, parse_registers, signal helpers) plus cortex_m_decode_crash() accepting a binary crash payload
- arch/arch_registry.c: static registry, cortex_m registered as "cortex-m"
- tests/arch_test.c: 9 tests — lookup, NULL guard, decode_crash smoke
- CMakeLists.txt: arch sources added to mkdbg-native; arch_test ctest added