### PR TITLE
feat(pr8): add debug_session — RSP live debug client over UART

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(mkdbg-native
   src/seam.c
   src/dashboard.c
   src/wire.c
+  src/debug_session.c
   arch/cortex_m.c
   arch/arch_registry.c
   $<TARGET_OBJECTS:seam_lib>

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -1,0 +1,172 @@
+/* debug_session.c — Live debug session over UART (RSP client)
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "debug_session.h"
+#include "wire_host.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ── Internal state ──────────────────────────────────────────────────────── */
+
+struct DebugSession {
+    int fd;           /* serial port file descriptor */
+    int last_signal;  /* GDB signal from most recent stop reply */
+};
+
+/* ── Hex helpers (local) ─────────────────────────────────────────────────── */
+
+static int hex_nibble(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/* Parse the signal number from an RSP stop reply ("S05", "T05…"). */
+static int parse_stop_signal(const char *reply)
+{
+    if (reply[0] != 'S' && reply[0] != 'T') return -1;
+    int hi = hex_nibble(reply[1]);
+    int lo = hex_nibble(reply[2]);
+    if (hi < 0 || lo < 0) return -1;
+    return (hi << 4) | lo;
+}
+
+/* ── Lifecycle ───────────────────────────────────────────────────────────── */
+
+DebugSession *debug_session_open(const char *port, int baud)
+{
+    int fd = wire_serial_open(port, baud);
+    if (fd < 0) return NULL;
+
+    DebugSession *s = malloc(sizeof(DebugSession));
+    if (!s) {
+        close(fd);
+        return NULL;
+    }
+    s->fd          = fd;
+    s->last_signal = 0;
+    return s;
+}
+
+void debug_session_close(DebugSession *s)
+{
+    if (!s) return;
+    close(s->fd);
+    free(s);
+}
+
+/* ── Execution control ───────────────────────────────────────────────────── */
+
+int debug_session_continue(DebugSession *s)
+{
+    char resp[16];
+
+    /* 'c' gets S00 immediately (MCU resuming); then wait for halt stop reply. */
+    int rc = rsp_transaction(s->fd, "c", resp, sizeof(resp));
+    if (rc != WIRE_OK) return rc;
+
+    char stop[16];
+    rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    if (rc == WIRE_OK)
+        s->last_signal = parse_stop_signal(stop);
+    return rc;
+}
+
+int debug_session_step(DebugSession *s)
+{
+    /* 's' has NO immediate reply per RSP spec — send directly, not via
+     * rsp_transaction().  The stop-reply S05 arrives when DebugMonitor
+     * fires after the CPU executes one instruction. */
+    int rc = rsp_send_packet(s->fd, "s");
+    if (rc != WIRE_OK) return rc;
+
+    char stop[16];
+    rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    if (rc == WIRE_OK)
+        s->last_signal = parse_stop_signal(stop);
+    return rc;
+}
+
+/* ── Breakpoints ─────────────────────────────────────────────────────────── */
+
+int debug_session_set_hw_breakpoint(DebugSession *s, uint32_t addr)
+{
+    char cmd[32];
+    snprintf(cmd, sizeof(cmd), "Z1,%x,4", addr);
+
+    char resp[16];
+    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    if (rc != WIRE_OK) return rc;
+    return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr)
+{
+    char cmd[32];
+    snprintf(cmd, sizeof(cmd), "z1,%x,4", addr);
+
+    char resp[16];
+    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    if (rc != WIRE_OK) return rc;
+    return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+/* ── Register / memory inspection ───────────────────────────────────────── */
+
+int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS])
+{
+    /* RSP 'g' response: 17 registers × 8 hex chars = 136 chars, little-endian. */
+    char resp[256];
+    int rc = rsp_transaction(s->fd, "g", resp, sizeof(resp));
+    if (rc != WIRE_OK) return rc;
+    if (resp[0] == 'E') return WIRE_ERR_IO;
+
+    for (int i = 0; i < DEBUG_SESSION_NREGS; i++) {
+        const char *p = resp + i * 8;
+        uint32_t v = 0;
+        for (int b = 0; b < 4; b++) {
+            int hi = hex_nibble(p[b * 2]);
+            int lo = hex_nibble(p[b * 2 + 1]);
+            if (hi < 0 || lo < 0) return WIRE_ERR_PARSE;
+            v |= (uint32_t)((hi << 4) | lo) << (b * 8);  /* little-endian */
+        }
+        regs[i] = v;
+    }
+    return WIRE_OK;
+}
+
+int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *out)
+{
+    char cmd[32];
+    snprintf(cmd, sizeof(cmd), "m%x,%zx", addr, len);
+
+    /* Each byte encoded as 2 hex chars; add space for 'E' error replies. */
+    char resp[4096];
+    if (len * 2 + 4 > sizeof(resp)) return WIRE_ERR_OVERFLOW;
+
+    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    if (rc != WIRE_OK) return rc;
+    if (resp[0] == 'E') return WIRE_ERR_IO;
+
+    for (size_t i = 0; i < len; i++) {
+        int hi = hex_nibble(resp[i * 2]);
+        int lo = hex_nibble(resp[i * 2 + 1]);
+        if (hi < 0 || lo < 0) return WIRE_ERR_PARSE;
+        out[i] = (uint8_t)((hi << 4) | lo);
+    }
+    return WIRE_OK;
+}
+
+/* ── Status ──────────────────────────────────────────────────────────────── */
+
+int debug_session_last_signal(const DebugSession *s)
+{
+    return s ? s->last_signal : -1;
+}

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -1,0 +1,70 @@
+/* debug_session.h — Live debug session over UART (RSP client)
+ *
+ * Wraps wire_rsp_client into a high-level API for breakpoint/step/inspect.
+ * Used by debug_cli.c (PR 9) and debug_tui.c (PR 11).
+ *
+ * Target requirements:
+ *   - Cortex-M3/M4 firmware built with WIRE_LIVE_DEBUG=1
+ *   - DebugMonitor priority not masked by BASEPRI/PRIMASK
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef DEBUG_SESSION_H
+#define DEBUG_SESSION_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Opaque session handle. */
+typedef struct DebugSession DebugSession;
+
+/* Number of Cortex-M registers returned by debug_session_read_regs().
+ * Order: r0-r12, sp(r13), lr(r14), pc(r15), xpsr  — matches RSP 'g' layout. */
+#define DEBUG_SESSION_NREGS 17
+
+/* ── Lifecycle ───────────────────────────────────────────────────────────── */
+
+/* Open UART port and return a new session.  baud=0 for PTY (QEMU).
+ * Returns NULL on error (error printed to stderr). */
+DebugSession *debug_session_open(const char *port, int baud);
+
+/* Close UART and free the session. */
+void debug_session_close(DebugSession *s);
+
+/* ── Execution control ───────────────────────────────────────────────────── */
+
+/* Resume MCU execution; block until the next halt (breakpoint or step).
+ * Returns WIRE_OK on halt, WIRE_ERR_TIMEOUT if no halt within 60 s. */
+int debug_session_continue(DebugSession *s);
+
+/* Execute one instruction; block until DebugMonitor fires.
+ * Returns WIRE_OK on halt, WIRE_ERR_TIMEOUT if step takes > 60 s. */
+int debug_session_step(DebugSession *s);
+
+/* ── Breakpoints ─────────────────────────────────────────────────────────── */
+
+/* Set FPBv1 hardware breakpoint at addr.
+ * Returns WIRE_OK, or WIRE_ERR_IO if all comparators are occupied. */
+int debug_session_set_hw_breakpoint(DebugSession *s, uint32_t addr);
+
+/* Clear hardware breakpoint previously set at addr.
+ * Returns WIRE_OK, or WIRE_ERR_IO if addr was not an active breakpoint. */
+int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr);
+
+/* ── Register / memory inspection ───────────────────────────────────────── */
+
+/* Read all CPU registers into regs[DEBUG_SESSION_NREGS].
+ * Indices: 0-12 = r0-r12, 13 = sp, 14 = lr, 15 = pc, 16 = xpsr. */
+int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS]);
+
+/* Read len bytes from target address addr into out.
+ * Returns WIRE_OK, or WIRE_ERR_IO if address is out of the allowed RAM range. */
+int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *out);
+
+/* ── Status ──────────────────────────────────────────────────────────────── */
+
+/* GDB signal number from the most recent stop reply (5=SIGTRAP, 11=SIGSEGV).
+ * Valid after debug_session_continue() or debug_session_step() returns WIRE_OK. */
+int debug_session_last_signal(const DebugSession *s);
+
+#endif /* DEBUG_SESSION_H */


### PR DESCRIPTION
src/debug_session.h + src/debug_session.c:
- DebugSession wraps wire_rsp_client into a high-level debug API
- debug_session_open/close: open UART via wire_serial_open
- debug_session_continue: sends 'c' (gets S00), then rsp_wait_for_stop
- debug_session_step: sends 's' via rsp_send_packet (no imm reply), then rsp_wait_for_stop; last_signal updated on return
- debug_session_set/clear_hw_breakpoint: RSP Z1/z1 commands
- debug_session_read_regs: RSP 'g', parse 17 little-endian uint32_t
- debug_session_read_mem: RSP 'm addr,len', hex decode to uint8_t[]
- debug_session_last_signal: accessor for last S/T stop signal

deps/wire bumped to include:
- wire_debug_loop spontaneous stop reply
- rsp_send_packet promoted from static
- rsp_wait_for_stop added

CMakeLists.txt: add src/debug_session.c to mkdbg-native sources