### PR TITLE
feat(arch): arch-aware debug session + RISC-V 32-bit plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(mkdbg-native
   src/dwarf.c
   src/termbox2_impl.c
   arch/cortex_m.c
+  arch/riscv32.c
   arch/arch_registry.c
   $<TARGET_OBJECTS:seam_lib>
   $<TARGET_OBJECTS:wire_crash_lib>
@@ -145,6 +146,7 @@ set_tests_properties(seam_analyze_kdi_cascade PROPERTIES
 add_executable(arch_test
   tests/arch_test.c
   arch/cortex_m.c
+  arch/riscv32.c
   arch/arch_registry.c
 )
 target_compile_options(arch_test PRIVATE -Wall -Wextra -Werror -O2)

--- a/arch/arch.h
+++ b/arch/arch.h
@@ -21,7 +21,16 @@
 /* MkdbgCrashReport aliases WireCrashReport for the arch layer. */
 typedef WireCrashReport MkdbgCrashReport;
 
+/* Live-debug register layout for a given arch.
+ * Used by debug_session and debug_tui to avoid hardcoding Cortex-M specifics. */
 typedef struct {
+    int         nregs;         /* total registers returned by RSP 'g' command */
+    int         pc_reg_idx;    /* index of PC in the register array */
+    int         sp_reg_idx;    /* index of SP in the register array */
+    const char *reg_names[64]; /* register names, NULL-terminated */
+} ArchLiveDebug;
+
+typedef struct MkdbgArch {
     const char *name;  /* arch name matched by --arch flag, e.g. "cortex-m" */
 
     /*
@@ -34,6 +43,9 @@ typedef struct {
      * Returns 0 on success, -1 on error (bad length, parse failure, etc.).
      */
     int (*decode_crash)(const uint8_t *raw, size_t len, MkdbgCrashReport *out);
+
+    /* Live debug register layout.  NULL if the arch doesn't support live debug. */
+    const ArchLiveDebug *live_debug;
 } MkdbgArch;
 
 /* Returns the registered arch whose name matches (case-sensitive), or NULL. */

--- a/arch/arch_registry.c
+++ b/arch/arch_registry.c
@@ -10,9 +10,11 @@
 #include <string.h>
 
 extern const MkdbgArch cortex_m_arch;
+extern const MkdbgArch riscv32_arch;
 
 static const MkdbgArch *arches[] = {
     &cortex_m_arch,
+    &riscv32_arch,
     NULL,
 };
 

--- a/arch/cortex_m.c
+++ b/arch/cortex_m.c
@@ -241,9 +241,21 @@ static int cortex_m_decode_crash(const uint8_t *raw, size_t len,
 
 /* ── exported arch descriptor ────────────────────────────────────────────── */
 
+static const ArchLiveDebug cortex_m_live = {
+    .nregs       = 17,
+    .pc_reg_idx  = 15,
+    .sp_reg_idx  = 13,
+    .reg_names   = {
+        "r0","r1","r2","r3","r4","r5","r6","r7",
+        "r8","r9","r10","r11","r12","sp","lr","pc","xpsr",
+        NULL
+    },
+};
+
 const MkdbgArch cortex_m_arch = {
     .name         = "cortex-m",
     .decode_crash = cortex_m_decode_crash,
+    .live_debug   = &cortex_m_live,
 };
 
 /* suppress "unused function" warnings for parse_registers / parse_halt_signal

--- a/arch/riscv32.c
+++ b/arch/riscv32.c
@@ -1,0 +1,46 @@
+/* arch/riscv32.c — RISC-V 32-bit arch plugin
+ *
+ * Live debug register layout:
+ *   x0-x31 (32 general-purpose registers) + pc = 33 registers.
+ *   RSP 'g' returns 33 × 8 hex chars = 264 chars, little-endian.
+ *
+ *   Notable aliases: x1=ra, x2=sp, x3=gp, x4=tp, x5-x7=t0-t2,
+ *   x8=s0/fp, x9=s1, x10-x11=a0-a1, x12-x17=a2-a7, x18-x27=s2-s11,
+ *   x28-x31=t3-t6, x32=pc.
+ *
+ * decode_crash: not yet implemented (no wire firmware port for RISC-V).
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "arch.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+static int riscv32_decode_crash(const uint8_t *raw, size_t len,
+                                 MkdbgCrashReport *out)
+{
+    (void)raw; (void)len; (void)out;
+    return -1;  /* not yet implemented */
+}
+
+static const ArchLiveDebug riscv32_live = {
+    .nregs      = 33,
+    .pc_reg_idx = 32,
+    .sp_reg_idx = 2,   /* x2 = sp */
+    .reg_names  = {
+        "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+        "x8", "x9", "x10","x11","x12","x13","x14","x15",
+        "x16","x17","x18","x19","x20","x21","x22","x23",
+        "x24","x25","x26","x27","x28","x29","x30","x31",
+        "pc",
+        NULL
+    },
+};
+
+const MkdbgArch riscv32_arch = {
+    .name         = "riscv32",
+    .decode_crash = riscv32_decode_crash,
+    .live_debug   = &riscv32_live,
+};

--- a/src/debug_cli.c
+++ b/src/debug_cli.c
@@ -126,9 +126,18 @@ static void trim_eol(char *s)
 
 static void do_break(DebugSession *s, const char *args)
 {
-    if (!*args) { printf("usage: break 0x<addr>\n"); return; }
+    if (!*args) { printf("usage: break 0x<addr> | break <symbol>\n"); return; }
 
-    uint32_t addr = parse_addr(args);
+    uint32_t addr;
+    if (args[0] == '0' && (args[1] == 'x' || args[1] == 'X')) {
+        addr = parse_addr(args);
+    } else if (s_dbi && dwarf_sym_to_addr(s_dbi, args, &addr) == 0) {
+        printf("(symbol '%s' = 0x%08x)\n", args, addr);
+    } else if (!s_dbi) {
+        printf("error: pass --elf to use symbol names\n"); return;
+    } else {
+        printf("error: symbol '%s' not found in ELF\n", args); return;
+    }
     if (debug_session_set_hw_breakpoint(s, addr) != WIRE_OK) {
         printf("error: could not set breakpoint (no free FPB comparator?)\n");
         return;
@@ -210,6 +219,7 @@ static void print_help(void)
     printf(
         "Commands:\n"
         "  break 0x<addr>      set hardware breakpoint (FPBv1)\n"
+        "  break <symbol>      set breakpoint at named function (requires --elf)\n"
         "  clear <id>          clear breakpoint by number\n"
         "  continue  (c)       resume execution; wait for next halt\n"
         "  step      (s)       single-step one instruction\n"

--- a/src/debug_cli.c
+++ b/src/debug_cli.c
@@ -34,6 +34,45 @@ static Breakpoint s_bp[BP_MAX];
 static int        s_bp_count  = 0;
 static int        s_bp_nextid = 1;
 
+/* ── Watchpoint list (DWT) ───────────────────────────────────────────────── */
+
+#define WP_MAX 4  /* DWT comparator hardware limit */
+
+typedef struct { int id; uint32_t addr; WatchpointType type; } Watchpoint;
+
+static Watchpoint s_wp[WP_MAX];
+static int        s_wp_count  = 0;
+static int        s_wp_nextid = 1;
+
+static int wp_add(uint32_t addr, WatchpointType type)
+{
+    if (s_wp_count >= WP_MAX) return -1;
+    s_wp[s_wp_count].id   = s_wp_nextid++;
+    s_wp[s_wp_count].addr = addr;
+    s_wp[s_wp_count].type = type;
+    s_wp_count++;
+    return s_wp[s_wp_count - 1].id;
+}
+
+static int wp_remove(int id, uint32_t *addr_out)
+{
+    for (int i = 0; i < s_wp_count; i++) {
+        if (s_wp[i].id == id) {
+            *addr_out = s_wp[i].addr;
+            s_wp[i]   = s_wp[--s_wp_count];
+            return 0;
+        }
+    }
+    return -1;
+}
+
+/* ── Memory display list ─────────────────────────────────────────────────── */
+
+#define DISPLAY_MAX 8
+
+static uint32_t s_display[DISPLAY_MAX];
+static int      s_ndisplay = 0;
+
 static int bp_add(uint32_t addr)
 {
     if (s_bp_count >= BP_MAX) return -1;
@@ -214,20 +253,92 @@ static void do_info_breakpoints(void)
         printf("%-4d 0x%08x\n", s_bp[i].id, s_bp[i].addr);
 }
 
+static void do_watch(DebugSession *s, const char *args, WatchpointType type)
+{
+    if (!*args) {
+        printf("usage: watch/rwatch/awatch 0x<addr>\n"); return;
+    }
+    uint32_t addr = parse_addr(args);
+    if (debug_session_set_watchpoint(s, addr, 1, type) != WIRE_OK) {
+        printf("error: could not set watchpoint (no free DWT comparator?)\n");
+        return;
+    }
+    int id = wp_add(addr, type);
+    if (id < 0) {
+        debug_session_clear_watchpoint(s, addr);
+        printf("error: watchpoint list full\n");
+        return;
+    }
+    const char *tname = (type == WATCHPOINT_WRITE)  ? "write"  :
+                        (type == WATCHPOINT_READ)   ? "read"   : "access";
+    printf("Watchpoint %d at 0x%08x (%s)\n", id, addr, tname);
+}
+
+static void do_delete_watch(DebugSession *s, const char *args)
+{
+    if (!*args) { printf("usage: delete watch <id>\n"); return; }
+    int id = atoi(args);
+    uint32_t addr;
+    if (wp_remove(id, &addr) != 0) {
+        printf("error: no watchpoint %d\n", id); return;
+    }
+    if (debug_session_clear_watchpoint(s, addr) != WIRE_OK)
+        printf("warning: target returned error clearing watchpoint\n");
+    else
+        printf("Watchpoint %d (0x%08x) cleared.\n", id, addr);
+}
+
+static void do_info_watchpoints(void)
+{
+    if (s_wp_count == 0) { printf("No watchpoints.\n"); return; }
+    printf("Num  Address     Type\n");
+    for (int i = 0; i < s_wp_count; i++) {
+        const char *t = (s_wp[i].type == WATCHPOINT_WRITE)  ? "write"  :
+                        (s_wp[i].type == WATCHPOINT_READ)   ? "read"   : "access";
+        printf("%-4d 0x%08x  %s\n", s_wp[i].id, s_wp[i].addr, t);
+    }
+}
+
+static void do_display(const char *args)
+{
+    if (!*args) { printf("usage: display 0x<addr>\n"); return; }
+    if (s_ndisplay >= DISPLAY_MAX) { printf("error: display list full\n"); return; }
+    s_display[s_ndisplay++] = parse_addr(args);
+    printf("display %d: 0x%08x\n", s_ndisplay, s_display[s_ndisplay - 1]);
+}
+
+static void do_undisplay(const char *args)
+{
+    if (!*args) { printf("usage: undisplay <id>\n"); return; }
+    int id = atoi(args) - 1;
+    if (id < 0 || id >= s_ndisplay) { printf("error: no display %d\n", id + 1); return; }
+    for (int i = id; i < s_ndisplay - 1; i++) s_display[i] = s_display[i + 1];
+    s_ndisplay--;
+    printf("display %d removed\n", id + 1);
+}
+
 static void print_help(void)
 {
     printf(
         "Commands:\n"
-        "  break 0x<addr>      set hardware breakpoint (FPBv1)\n"
-        "  break <symbol>      set breakpoint at named function (requires --elf)\n"
-        "  clear <id>          clear breakpoint by number\n"
-        "  continue  (c)       resume execution; wait for next halt\n"
-        "  step      (s)       single-step one instruction\n"
-        "  regs                print all CPU registers\n"
-        "  mem 0x<addr> [len]  hexdump memory (default 16 bytes, max 256)\n"
-        "  info breakpoints    list active breakpoints\n"
-        "  tui                 TUI mode (PR 11)\n"
-        "  quit      (q)       resume MCU and exit\n"
+        "  break 0x<addr>           set hardware breakpoint (FPBv1)\n"
+        "  break <symbol>           set breakpoint at named function (requires --elf)\n"
+        "  clear <id>               clear breakpoint by number\n"
+        "  watch 0x<addr>           DWT write watchpoint\n"
+        "  rwatch 0x<addr>          DWT read watchpoint\n"
+        "  awatch 0x<addr>          DWT read+write watchpoint\n"
+        "  delete watch <id>        clear DWT watchpoint by number\n"
+        "  display 0x<addr>         add memory address to display list\n"
+        "  undisplay <id>           remove from display list\n"
+        "  continue  (c)            resume execution; wait for next halt\n"
+        "  step      (s)            single-step one instruction\n"
+        "  regs                     print all CPU registers\n"
+        "  mem 0x<addr> [len]       hexdump memory (default 16 bytes, max 256)\n"
+        "  info breakpoints         list active breakpoints\n"
+        "  info watchpoints         list active DWT watchpoints\n"
+        "  info display             list memory display addresses\n"
+        "  tui                      TUI mode\n"
+        "  quit      (q)            resume MCU and exit\n"
     );
 }
 
@@ -262,6 +373,9 @@ int cmd_debug(const DebugOptions *opts)
     /* Reset state for this session */
     s_bp_count  = 0;
     s_bp_nextid = 1;
+    s_wp_count  = 0;
+    s_wp_nextid = 1;
+    s_ndisplay  = 0;
 
     char line[256];
     for (;;) {
@@ -292,11 +406,31 @@ int cmd_debug(const DebugOptions *opts)
             do_regs(s);
         } else if (strcmp(cmd, "mem") == 0) {
             do_mem(s, args);
+        } else if (strcmp(cmd, "watch") == 0) {
+            do_watch(s, args, WATCHPOINT_WRITE);
+        } else if (strcmp(cmd, "rwatch") == 0) {
+            do_watch(s, args, WATCHPOINT_READ);
+        } else if (strcmp(cmd, "awatch") == 0) {
+            do_watch(s, args, WATCHPOINT_ACCESS);
+        } else if (strcmp(cmd, "delete") == 0) {
+            char sub[16];
+            const char *rest = split_token(args, sub, sizeof(sub));
+            if (strcmp(sub, "watch") == 0) do_delete_watch(s, rest);
+            else printf("delete: unknown subcommand '%s'\n", sub);
+        } else if (strcmp(cmd, "display") == 0) {
+            do_display(args);
+        } else if (strcmp(cmd, "undisplay") == 0) {
+            do_undisplay(args);
         } else if (strcmp(cmd, "info") == 0) {
             char sub[32];
             split_token(args, sub, sizeof(sub));
             if (strcmp(sub, "breakpoints") == 0) do_info_breakpoints();
-            else printf("info: unknown subcommand '%s'\n", sub);
+            else if (strcmp(sub, "watchpoints") == 0) do_info_watchpoints();
+            else if (strcmp(sub, "display") == 0) {
+                if (s_ndisplay == 0) printf("No display addresses.\n");
+                else for (int i = 0; i < s_ndisplay; i++)
+                    printf("%d: 0x%08x\n", i + 1, s_display[i]);
+            } else printf("info: unknown subcommand '%s'\n", sub);
         } else if (strcmp(cmd, "tui") == 0) {
             int ret = debug_tui_run(s, s_dbi);
             if (ret == TUI_QUIT) {

--- a/src/debug_cli.c
+++ b/src/debug_cli.c
@@ -19,6 +19,7 @@
 #include "debug_tui.h"
 #include "dwarf.h"
 #include "wire_host.h"
+#include "arch.h"
 
 /* ── Session-scoped DWARF handle (NULL if no --elf provided) ─────────────── */
 
@@ -107,22 +108,15 @@ static const char *signal_name(int sig)
     }
 }
 
-static const char *reg_name(int i)
-{
-    static const char *names[17] = {
-        "r0","r1","r2","r3","r4","r5","r6","r7",
-        "r8","r9","r10","r11","r12","sp","lr","pc","xpsr"
-    };
-    return (i >= 0 && i < 17) ? names[i] : "??";
-}
+/* reg_name is now delegated to debug_session_reg_name(s, i) at call sites */
 
 static void print_halt(DebugSession *s)
 {
     int sig = debug_session_last_signal(s);
     printf("Halted.  signal=%d (%s)", sig, signal_name(sig));
-    uint32_t regs[DEBUG_SESSION_NREGS];
+    uint32_t regs[DEBUG_SESSION_MAX_REGS];
     if (debug_session_read_regs(s, regs) == WIRE_OK) {
-        uint32_t pc = regs[15];
+        uint32_t pc = regs[debug_session_pc_reg(s)];
         printf("  pc=0x%08x", pc);
         if (s_dbi) {
             DwarfLocation loc;
@@ -208,19 +202,16 @@ static void do_clear(DebugSession *s, const char *args)
 
 static void do_regs(DebugSession *s)
 {
-    uint32_t regs[DEBUG_SESSION_NREGS];
+    uint32_t regs[DEBUG_SESSION_MAX_REGS];
     if (debug_session_read_regs(s, regs) != WIRE_OK) {
         printf("error: failed to read registers\n");
         return;
     }
-    /* r0–r12: four per row */
-    for (int i = 0; i <= 12; i++) {
-        printf("%-4s 0x%08x", reg_name(i), regs[i]);
-        printf(((i % 4) == 3 || i == 12) ? "\n" : "   ");
+    int nregs = debug_session_nregs(s);
+    for (int i = 0; i < nregs; i++) {
+        printf("%-6s 0x%08x", debug_session_reg_name(s, i), regs[i]);
+        printf(((i % 4) == 3 || i == nregs - 1) ? "\n" : "   ");
     }
-    printf("sp   0x%08x   lr   0x%08x   pc   0x%08x\n",
-           regs[13], regs[14], regs[15]);
-    printf("xpsr 0x%08x\n", regs[16]);
 }
 
 static void do_mem(DebugSession *s, const char *args)
@@ -352,7 +343,12 @@ int cmd_debug(const DebugOptions *opts)
     if (!port || !*port)
         die("debug requires --port; e.g. mkdbg debug --port /dev/ttyUSB0");
 
-    DebugSession *s = debug_session_open(port, baud);
+    const char     *arch_name = opts->arch ? opts->arch : "cortex-m";
+    const MkdbgArch *arch     = mkdbg_arch_find(arch_name);
+    if (!arch || !arch->live_debug)
+        die("arch '%s' does not support live debug", arch_name);
+
+    DebugSession *s = debug_session_open(port, baud, arch);
     if (!s) return 1;
 
     printf("mkdbg live debug  port=%s  baud=%d\n", port, baud);

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -124,6 +124,34 @@ int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr)
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
 
+/* ── DWT Hardware Watchpoints ────────────────────────────────────────────── */
+
+int debug_session_set_watchpoint(DebugSession *s, uint32_t addr,
+                                  uint32_t len, WatchpointType type)
+{
+    char cmd[32];
+    snprintf(cmd, sizeof(cmd), "Z%d,%x,%x", (int)type, addr, len ? len : 1);
+
+    char resp[16];
+    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    if (rc != WIRE_OK) return rc;
+    return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr)
+{
+    /* Try all three types (write/read/access) — firmware matches by address. */
+    char cmd[32];
+    char resp[16];
+    int types[3] = { WATCHPOINT_WRITE, WATCHPOINT_READ, WATCHPOINT_ACCESS };
+    for (int i = 0; i < 3; i++) {
+        snprintf(cmd, sizeof(cmd), "z%d,%x,1", types[i], addr);
+        int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+        if (rc == WIRE_OK && strcmp(resp, "OK") == 0) return WIRE_OK;
+    }
+    return WIRE_ERR_IO;
+}
+
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
 int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS])

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -4,6 +4,7 @@
  */
 
 #include "debug_session.h"
+#include "arch.h"
 #include "wire_host.h"
 
 #include <stdio.h>
@@ -14,8 +15,9 @@
 /* ── Internal state ──────────────────────────────────────────────────────── */
 
 struct DebugSession {
-    int fd;           /* serial port file descriptor */
-    int last_signal;  /* GDB signal from most recent stop reply */
+    int              fd;           /* serial port file descriptor */
+    int              last_signal;  /* GDB signal from most recent stop reply */
+    const MkdbgArch *arch;         /* active architecture (live_debug guaranteed non-NULL) */
 };
 
 /* ── Hex helpers (local) ─────────────────────────────────────────────────── */
@@ -40,7 +42,8 @@ static int parse_stop_signal(const char *reply)
 
 /* ── Lifecycle ───────────────────────────────────────────────────────────── */
 
-DebugSession *debug_session_open(const char *port, int baud)
+DebugSession *debug_session_open(const char *port, int baud,
+                                  const MkdbgArch *arch)
 {
     int fd = wire_serial_open(port, baud);
     if (fd < 0) return NULL;
@@ -52,6 +55,7 @@ DebugSession *debug_session_open(const char *port, int baud)
     }
     s->fd          = fd;
     s->last_signal = 0;
+    s->arch        = arch;
     return s;
 }
 
@@ -154,15 +158,16 @@ int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr)
 
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
-int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS])
+int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_MAX_REGS])
 {
-    /* RSP 'g' response: 17 registers × 8 hex chars = 136 chars, little-endian. */
-    char resp[256];
+    int nregs = s->arch->live_debug->nregs;
+    /* RSP 'g': nregs registers × 8 hex chars each, little-endian. */
+    char resp[DEBUG_SESSION_MAX_REGS * 8 + 4];
     int rc = rsp_transaction(s->fd, "g", resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     if (resp[0] == 'E') return WIRE_ERR_IO;
 
-    for (int i = 0; i < DEBUG_SESSION_NREGS; i++) {
+    for (int i = 0; i < nregs; i++) {
         const char *p = resp + i * 8;
         uint32_t v = 0;
         for (int b = 0; b < 4; b++) {
@@ -196,6 +201,24 @@ int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *
         out[i] = (uint8_t)((hi << 4) | lo);
     }
     return WIRE_OK;
+}
+
+/* ── Arch metadata ───────────────────────────────────────────────────────── */
+
+int debug_session_nregs(const DebugSession *s)
+{
+    return s ? s->arch->live_debug->nregs : 0;
+}
+
+const char *debug_session_reg_name(const DebugSession *s, int i)
+{
+    if (!s || i < 0 || i >= s->arch->live_debug->nregs) return "??";
+    return s->arch->live_debug->reg_names[i];
+}
+
+int debug_session_pc_reg(const DebugSession *s)
+{
+    return s ? s->arch->live_debug->pc_reg_idx : 0;
 }
 
 /* ── Status ──────────────────────────────────────────────────────────────── */

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -55,6 +55,24 @@ int debug_session_set_hw_breakpoint(DebugSession *s, uint32_t addr);
  * Returns WIRE_OK, or WIRE_ERR_IO if addr was not an active breakpoint. */
 int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr);
 
+/* ── DWT Hardware Watchpoints ────────────────────────────────────────────── */
+
+/* Watchpoint type matches GDB RSP Z-packet type codes. */
+typedef enum {
+    WATCHPOINT_WRITE  = 2,  /* Z2 — halt on write to addr */
+    WATCHPOINT_READ   = 3,  /* Z3 — halt on read from addr */
+    WATCHPOINT_ACCESS = 4,  /* Z4 — halt on read or write */
+} WatchpointType;
+
+/* Set a DWT hardware watchpoint at addr (len bytes, exact match when len=1).
+ * Returns WIRE_OK, or WIRE_ERR_IO if all DWT comparators are occupied. */
+int debug_session_set_watchpoint(DebugSession *s, uint32_t addr,
+                                  uint32_t len, WatchpointType type);
+
+/* Clear DWT watchpoint at addr.
+ * Returns WIRE_OK, or WIRE_ERR_IO if addr was not an active watchpoint. */
+int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr);
+
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
 /* Read all CPU registers into regs[DEBUG_SESSION_NREGS].

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -15,18 +15,23 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* Forward-declare MkdbgArch to avoid circular includes. */
+typedef struct MkdbgArch MkdbgArch;
+
 /* Opaque session handle. */
 typedef struct DebugSession DebugSession;
 
-/* Number of Cortex-M registers returned by debug_session_read_regs().
- * Order: r0-r12, sp(r13), lr(r14), pc(r15), xpsr  — matches RSP 'g' layout. */
-#define DEBUG_SESSION_NREGS 17
+/* Maximum registers any supported arch can return from RSP 'g'.
+ * Cortex-M: 17.  RISC-V 32: 33.  Increase if a future arch needs more. */
+#define DEBUG_SESSION_MAX_REGS 64
 
 /* ── Lifecycle ───────────────────────────────────────────────────────────── */
 
 /* Open UART port and return a new session.  baud=0 for PTY (QEMU).
+ * arch must point to an MkdbgArch with a valid live_debug descriptor.
  * Returns NULL on error (error printed to stderr). */
-DebugSession *debug_session_open(const char *port, int baud);
+DebugSession *debug_session_open(const char *port, int baud,
+                                  const MkdbgArch *arch);
 
 /* Close UART and free the session. */
 void debug_session_close(DebugSession *s);
@@ -75,13 +80,25 @@ int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr);
 
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
-/* Read all CPU registers into regs[DEBUG_SESSION_NREGS].
- * Indices: 0-12 = r0-r12, 13 = sp, 14 = lr, 15 = pc, 16 = xpsr. */
-int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS]);
+/* Read all CPU registers into regs[].  The number of registers is arch-dependent;
+ * use debug_session_nregs() to find out how many were written.
+ * regs must have room for at least DEBUG_SESSION_MAX_REGS elements. */
+int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_MAX_REGS]);
 
 /* Read len bytes from target address addr into out.
  * Returns WIRE_OK, or WIRE_ERR_IO if address is out of the allowed RAM range. */
 int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *out);
+
+/* ── Arch metadata ───────────────────────────────────────────────────────── */
+
+/* Number of registers returned by debug_session_read_regs() for this session. */
+int debug_session_nregs(const DebugSession *s);
+
+/* Register name at index i (e.g. "r0", "pc", "x2").  Returns "??" if out of range. */
+const char *debug_session_reg_name(const DebugSession *s, int i);
+
+/* Index of the PC register (e.g. 15 for Cortex-M, 32 for RISC-V). */
+int debug_session_pc_reg(const DebugSession *s);
 
 /* ── Status ──────────────────────────────────────────────────────────────── */
 

--- a/src/debug_tui.c
+++ b/src/debug_tui.c
@@ -34,19 +34,25 @@
 
 #define REG_ROWS     8    /* register panel content rows (r0-r12 + sp/lr/pc/xpsr) */
 #define CTX_HALF     4    /* source context: ±4 lines around PC = 9 visible lines */
-#define MAX_WATCHES  4
+#define MAX_DISPLAY  4
+#define TUI_WP_MAX   4
 
 /* ── Local state ─────────────────────────────────────────────────────────── */
 
 #define TUI_BP_MAX 8
 typedef struct { int id; uint32_t addr; } TuiBP;
+typedef struct { int id; uint32_t addr; WatchpointType type; } TuiWP;
 
 static TuiBP    s_bp[TUI_BP_MAX];
 static int      s_nbp      = 0;
 static int      s_bp_next  = 1;
 
-static uint32_t s_watches[MAX_WATCHES];
-static int      s_nwatches = 0;
+static TuiWP    s_wpts[TUI_WP_MAX];
+static int      s_nwpts    = 0;
+static int      s_wp_next  = 1;
+
+static uint32_t s_display[MAX_DISPLAY];
+static int      s_ndisplay = 0;
 
 static uint32_t s_regs[DEBUG_SESSION_NREGS];
 static int      s_regs_ok  = 0;
@@ -187,7 +193,7 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
     hline(y0, 12, split);
     bchar(split, y0, "\xe2\x94\xac");                  /* ┬ */
     tb_print(split + 1, y0, TB_CYAN, TB_DEFAULT,
-             "\xe2\x94\x80 Breakpoints ");
+             "\xe2\x94\x80 BP / WP ");
     hline(y0, split + 14, w - 1);
     bchar(w - 1, y0, "\xe2\x94\xa4");                  /* ┤ */
 
@@ -219,7 +225,7 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
 
         bchar(split, y0 + 1 + r, "\xe2\x94\x82");      /* │ middle */
 
-        /* ── Breakpoints (right half) ── */
+        /* ── Breakpoints + Watchpoints (right half) ── */
         if (r < s_nbp) {
             DwarfLocation loc;
             char loc_str[64] = "";
@@ -229,9 +235,17 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
                 snprintf(loc_str, sizeof(loc_str), " %s:%d", base, loc.line);
             }
             tb_printf(split + 1, y0 + 1 + r, TB_DEFAULT, TB_DEFAULT,
-                      " #%-2d 0x%08x%-*s",
+                      " #%-2d 0x%08x (BP)%-*s",
                       s_bp[r].id, s_bp[r].addr,
-                      bp_content_w - 18, loc_str);
+                      bp_content_w - 22, loc_str);
+        } else if (r - s_nbp < s_nwpts) {
+            int wi = r - s_nbp;
+            const char *t = (s_wpts[wi].type == WATCHPOINT_WRITE)  ? "W " :
+                            (s_wpts[wi].type == WATCHPOINT_READ)   ? "R " : "RW";
+            tb_printf(split + 1, y0 + 1 + r, TB_YELLOW, TB_DEFAULT,
+                      " W%-2d 0x%08x (%s)%-*s",
+                      s_wpts[wi].id, s_wpts[wi].addr, t,
+                      bp_content_w - 24, "");
         }
         (void)bp_content_w;
 
@@ -255,9 +269,9 @@ static void draw_mem(int y0, int h, int w, DebugSession *s)
 
     for (int r = 0; r < h; r++) {
         bchar(0, y0 + 1 + r, "\xe2\x94\x82");
-        if (r < s_nwatches) {
+        if (r < s_ndisplay) {
             uint8_t buf[16];
-            if (debug_session_read_mem(s, s_watches[r], 16, buf) == WIRE_OK) {
+            if (debug_session_read_mem(s, s_display[r], 16, buf) == WIRE_OK) {
                 char hex[64];
                 int pos = 0;
                 for (int i = 0; i < 16; i++) {
@@ -266,10 +280,10 @@ static void draw_mem(int y0, int h, int w, DebugSession *s)
                 }
                 hex[pos > 0 ? pos - 1 : 0] = '\0';
                 tb_printf(2, y0 + 1 + r, TB_DEFAULT, TB_DEFAULT,
-                          "0x%08x: %s", s_watches[r], hex);
+                          "0x%08x: %s", s_display[r], hex);
             } else {
                 tb_printf(2, y0 + 1 + r, TB_RED, TB_DEFAULT,
-                          "0x%08x: <read error>", s_watches[r]);
+                          "0x%08x: <read error>", s_display[r]);
             }
         }
         bchar(w - 1, y0 + 1 + r, "\xe2\x94\x82");
@@ -285,7 +299,7 @@ static void draw_bottom(int y_border, int y_hint, int w)
     bchar(w - 1, y_border, "\xe2\x94\x98");            /* ┘ */
 
     tb_print(0, y_hint, TB_YELLOW, TB_DEFAULT,
-             "[s]tep [c]ontinue [b]reak [d]el [m]em [t]cli [q]uit");
+             "[s]tep [c]ontinue [b]reak [d]el [w]atch [m]em [t]cli [q]uit");
 }
 
 /* ── Status bar (replaces hint bar during blocking ops) ──────────────────── */
@@ -308,7 +322,7 @@ static void redraw(DebugSession *s, DwarfDBI *dbi)
     tb_clear();
 
     /* Compute panel heights */
-    int mem_h  = (s_nwatches > 0) ? s_nwatches : 1;
+    int mem_h  = (s_ndisplay > 0) ? s_ndisplay : 1;
     int src_h  = h - REG_ROWS - mem_h - 6;
     /* 6 = top_border(1) + reg_sep(1) + mem_sep(1) + bottom_border(1) + hint(1) + 1 spare */
     if (src_h < 3) src_h = 3;
@@ -396,7 +410,9 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
     /* Reset local state */
     s_nbp      = 0;
     s_bp_next  = 1;
-    s_nwatches = 0;
+    s_nwpts    = 0;
+    s_wp_next  = 1;
+    s_ndisplay = 0;
     s_regs_ok  = 0;
     s_pc       = 0;
 
@@ -467,11 +483,28 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             redraw(s, dbi);
 
         } else if (ev.ch == 'm') {
-            if (s_nwatches < MAX_WATCHES) {
+            if (s_ndisplay < MAX_DISPLAY) {
+                char inp[32] = "";
+                if (tui_prompt(y_hint, w, "display addr> 0x", inp, sizeof(inp)) == 0
+                        && inp[0]) {
+                    s_display[s_ndisplay++] = (uint32_t)strtoul(inp, NULL, 16);
+                }
+            }
+            redraw(s, dbi);
+
+        } else if (ev.ch == 'w') {
+            if (s_nwpts < TUI_WP_MAX) {
                 char inp[32] = "";
                 if (tui_prompt(y_hint, w, "watch addr> 0x", inp, sizeof(inp)) == 0
                         && inp[0]) {
-                    s_watches[s_nwatches++] = (uint32_t)strtoul(inp, NULL, 16);
+                    uint32_t addr = (uint32_t)strtoul(inp, NULL, 16);
+                    if (addr && debug_session_set_watchpoint(
+                            s, addr, 1, WATCHPOINT_WRITE) == WIRE_OK) {
+                        s_wpts[s_nwpts].id   = s_wp_next++;
+                        s_wpts[s_nwpts].addr = addr;
+                        s_wpts[s_nwpts].type = WATCHPOINT_WRITE;
+                        s_nwpts++;
+                    }
                 }
             }
             redraw(s, dbi);

--- a/src/debug_tui.c
+++ b/src/debug_tui.c
@@ -54,7 +54,7 @@ static int      s_wp_next  = 1;
 static uint32_t s_display[MAX_DISPLAY];
 static int      s_ndisplay = 0;
 
-static uint32_t s_regs[DEBUG_SESSION_NREGS];
+static uint32_t s_regs[DEBUG_SESSION_MAX_REGS];
 static int      s_regs_ok  = 0;
 
 static uint32_t s_pc       = 0;
@@ -161,19 +161,10 @@ static void draw_source(int y0, int src_h, int w, DwarfDBI *dbi, uint32_t pc)
 
 /* ── Register/Breakpoint panel ───────────────────────────────────────────── */
 
-/* Register name at index 0-16 */
-static const char *rname(int i)
-{
-    static const char *n[] = {
-        "r0","r1","r2","r3","r4","r5","r6","r7",
-        "r8","r9","r10","r11","r12","sp","lr","pc","xpsr"
-    };
-    return (i >= 0 && i < 17) ? n[i] : "??";
-}
-
 /*
  * Register pairs displayed per row (left index, right index).
- * Rows: 0..REG_ROWS-1 = 8 rows.
+ * Rows: 0..REG_ROWS-1 = 8 rows.  Cortex-M layout; for other arches
+ * indices that exceed nregs are silently skipped.
  */
 static const int REG_PAIRS[REG_ROWS][2] = {
     {0, 8}, {1, 9}, {2, 10}, {3, 11}, {4, 12},
@@ -182,7 +173,7 @@ static const int REG_PAIRS[REG_ROWS][2] = {
     {6, 16},   /* r6, xpsr */
 };
 
-static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
+static void draw_reg_bp(int y0, int h, int w, DebugSession *s, DwarfDBI *dbi, uint32_t pc)
 {
     int split = w / 2;  /* column of the vertical separator ─ │ ─ */
 
@@ -204,24 +195,32 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
         bchar(0, y0 + 1 + r, "\xe2\x94\x82");          /* │ left edge */
 
         /* ── Registers (left half) ── */
+        int nregs = debug_session_nregs(s);
+        int pc_reg = debug_session_pc_reg(s);
         if (r < REG_ROWS && s_regs_ok) {
             int li = REG_PAIRS[r][0];
             int ri = REG_PAIRS[r][1];
             /* highlight pc with bold */
             uintattr_t pc_fg = TB_WHITE | TB_BOLD;
             uintattr_t pc_bg = TB_BLUE;
-            uintattr_t lfg = (li == 15) ? pc_fg : TB_DEFAULT;
-            uintattr_t lbg = (li == 15) ? pc_bg : TB_DEFAULT;
-            uintattr_t rfg = (ri == 15) ? pc_fg : TB_DEFAULT;
-            uintattr_t rbg = (ri == 15) ? pc_bg : TB_DEFAULT;
+            uintattr_t lfg = (li == pc_reg) ? pc_fg : TB_DEFAULT;
+            uintattr_t lbg = (li == pc_reg) ? pc_bg : TB_DEFAULT;
+            uintattr_t rfg = (ri == pc_reg) ? pc_fg : TB_DEFAULT;
+            uintattr_t rbg = (ri == pc_reg) ? pc_bg : TB_DEFAULT;
             char lbuf[20], rbuf[20];
-            snprintf(lbuf, sizeof(lbuf), "%-4s 0x%08x", rname(li), s_regs[li]);
-            snprintf(rbuf, sizeof(rbuf), "%-4s 0x%08x", rname(ri), s_regs[ri]);
+            if (li < nregs)
+                snprintf(lbuf, sizeof(lbuf), "%-6s 0x%08x",
+                         debug_session_reg_name(s, li), s_regs[li]);
+            else lbuf[0] = '\0';
+            if (ri < nregs)
+                snprintf(rbuf, sizeof(rbuf), "%-6s 0x%08x",
+                         debug_session_reg_name(s, ri), s_regs[ri]);
+            else rbuf[0] = '\0';
             tb_printf(1, y0 + 1 + r, lfg, lbg, " %-*s", reg_content_w / 2, lbuf);
             tb_printf(1 + reg_content_w / 2 + 1, y0 + 1 + r, rfg, rbg,
                       " %-*s", reg_content_w / 2, rbuf);
         }
-        (void)reg_content_w;
+        (void)reg_content_w; (void)nregs; (void)pc_reg;
 
         bchar(split, y0 + 1 + r, "\xe2\x94\x82");      /* │ middle */
 
@@ -334,7 +333,7 @@ static void redraw(DebugSession *s, DwarfDBI *dbi)
     int y_hint     = y_bottom + 1;
 
     draw_source(y_src_top, src_h, w, dbi, s_pc);
-    draw_reg_bp(y_reg_sep, REG_ROWS, w, dbi, s_pc);
+    draw_reg_bp(y_reg_sep, REG_ROWS, w, s, dbi, s_pc);
     draw_mem(y_mem_sep, mem_h, w, s);
     draw_bottom(y_bottom, y_hint, w);
 
@@ -419,7 +418,7 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
     /* Read initial register state */
     if (debug_session_read_regs(s, s_regs) == WIRE_OK) {
         s_regs_ok = 1;
-        s_pc = s_regs[15];
+        s_pc = s_regs[debug_session_pc_reg(s)];
     }
 
     redraw(s, dbi);
@@ -446,7 +445,7 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             int rc = debug_session_step(s);
             if (rc == WIRE_OK && debug_session_read_regs(s, s_regs) == WIRE_OK) {
                 s_regs_ok = 1;
-                s_pc = s_regs[15];
+                s_pc = s_regs[debug_session_pc_reg(s)];
             }
             redraw(s, dbi);
 
@@ -455,7 +454,7 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             int rc = debug_session_continue(s);
             if (rc == WIRE_OK && debug_session_read_regs(s, s_regs) == WIRE_OK) {
                 s_regs_ok = 1;
-                s_pc = s_regs[15];
+                s_pc = s_regs[debug_session_pc_reg(s)];
             }
             redraw(s, dbi);
 

--- a/src/debug_tui.c
+++ b/src/debug_tui.c
@@ -444,11 +444,17 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             redraw(s, dbi);
 
         } else if (ev.ch == 'b') {
-            char inp[32] = "";
-            if (tui_prompt(y_hint, w, "break addr> 0x", inp, sizeof(inp)) == 0
+            char inp[64] = "";
+            if (tui_prompt(y_hint, w, "break> ", inp, sizeof(inp)) == 0
                     && inp[0]) {
-                uint32_t addr = (uint32_t)strtoul(inp, NULL, 16);
-                tui_bp_add(s, addr);
+                uint32_t addr = 0;
+                if ((inp[0] == '0' && (inp[1] == 'x' || inp[1] == 'X')) ||
+                    (inp[0] >= '0' && inp[0] <= '9')) {
+                    addr = (uint32_t)strtoul(inp, NULL, 16);
+                } else if (dbi) {
+                    dwarf_sym_to_addr(dbi, inp, &addr);
+                }
+                if (addr) tui_bp_add(s, addr);
             }
             redraw(s, dbi);
 

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -60,6 +60,11 @@ struct DwarfDBI {
     char    **files;       /* heap-allocated resolved paths */
     size_t    nfiles;
     size_t    files_cap;
+    /* ELF symbol table (.symtab + .strtab) — pointers into elf_data */
+    const uint8_t *sym_data;   /* NULL if .symtab absent or stripped */
+    size_t         sym_count;  /* number of Elf32_Sym entries (16 bytes each) */
+    const uint8_t *str_data;   /* .strtab string table */
+    size_t         str_size;
 };
 
 /* ── Little-endian readers ───────────────────────────────────────────────── */
@@ -502,6 +507,19 @@ DwarfDBI *dwarf_open(const char *elf_path)
     if (dbi->nrows > 0)
         qsort(dbi->rows, dbi->nrows, sizeof(DwarfRow), row_cmp);
 
+    /* Optional: ELF symbol table for name→address lookups (e.g. break main).
+     * Failure here is non-fatal — dwarf_sym_to_addr() will return -1. */
+    const uint8_t *sym_p = NULL; size_t sym_sz = 0;
+    const uint8_t *str_p = NULL; size_t str_sz = 0;
+    if (find_elf_section(data, size, ".symtab", &sym_p, &sym_sz) == 0 &&
+        find_elf_section(data, size, ".strtab", &str_p, &str_sz) == 0 &&
+        sym_sz % 16 == 0) {
+        dbi->sym_data  = sym_p;
+        dbi->sym_count = sym_sz / 16;
+        dbi->str_data  = str_p;
+        dbi->str_size  = str_sz;
+    }
+
     return dbi;
 }
 
@@ -538,4 +556,30 @@ int dwarf_pc_to_location(DwarfDBI *dbi, uint32_t pc, DwarfLocation *out)
     out->line   = dbi->rows[idx].line;
     out->column = dbi->rows[idx].column;
     return 0;
+}
+
+int dwarf_sym_to_addr(DwarfDBI *dbi, const char *name, uint32_t *addr)
+{
+    if (!dbi || !dbi->sym_data || !name || !addr) return -1;
+    /* Walk Elf32_Sym entries (16 bytes each):
+     *   offset  0: st_name  (uint32_t) — index into .strtab
+     *   offset  4: st_value (uint32_t) — symbol address
+     *   offset  8: st_size  (uint32_t)
+     *   offset 12: st_info  (uint8_t)  — bits[3:0]=type; STT_FUNC=2
+     *   offset 13: st_other (uint8_t)
+     *   offset 14: st_shndx (uint16_t)
+     */
+    for (size_t i = 0; i < dbi->sym_count; i++) {
+        const uint8_t *e      = dbi->sym_data + i * 16;
+        uint32_t       st_nm  = le32(e + 0);
+        uint32_t       st_val = le32(e + 4);
+        uint8_t        st_inf = e[12];
+        if ((st_inf & 0xfu) != 2u) continue;           /* not STT_FUNC */
+        if (st_nm >= (uint32_t)dbi->str_size) continue;
+        if (strcmp((const char *)dbi->str_data + st_nm, name) == 0) {
+            *addr = st_val;
+            return 0;
+        }
+    }
+    return -1;
 }

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -34,4 +34,10 @@ void dwarf_close(DwarfDBI *dbi);
  *         -1  on internal error. */
 int dwarf_pc_to_location(DwarfDBI *dbi, uint32_t pc, DwarfLocation *out);
 
+/* Look up a function symbol by name in the ELF .symtab.
+ * Requires a non-stripped ELF (normal for firmware .elf files).
+ * Returns  0  and fills *addr on success,
+ *         -1  if not found or no symbol table present. */
+int dwarf_sym_to_addr(DwarfDBI *dbi, const char *name, uint32_t *addr);
+
 #endif /* DWARF_H */

--- a/src/mkdbg.h
+++ b/src/mkdbg.h
@@ -209,6 +209,7 @@ typedef struct {
   const char *port;
   int         baud;
   const char *elf_path;
+  const char *arch;  /* --arch name, e.g. "cortex-m"; NULL defaults to "cortex-m" */
 } DebugOptions;
 
 typedef struct {

--- a/src/parse.c
+++ b/src/parse.c
@@ -495,6 +495,9 @@ int parse_debug_args(int argc, char **argv, DebugOptions *opts)
     } else if (strcmp(argv[i], "--elf") == 0) {
       if (i + 1 >= argc) die("missing value for --elf");
       opts->elf_path = argv[++i];
+    } else if (strcmp(argv[i], "--arch") == 0) {
+      if (i + 1 >= argc) die("missing value for --arch");
+      opts->arch = argv[++i];
     } else if (argv[i][0] == '-') {
       die("unknown debug argument: %s", argv[i]);
     } else {

--- a/tests/arch_test.c
+++ b/tests/arch_test.c
@@ -60,6 +60,26 @@ int main(void)
               "zero payload: timeout flag set (halt_signal=0)");
     }
 
+    /* cortex-m live_debug descriptor */
+    CHECK(cm != NULL && cm->live_debug != NULL,
+          "cortex-m has live_debug descriptor");
+    CHECK(cm != NULL && cm->live_debug != NULL && cm->live_debug->nregs == 17,
+          "cortex-m live_debug->nregs == 17");
+    CHECK(cm != NULL && cm->live_debug != NULL && cm->live_debug->pc_reg_idx == 15,
+          "cortex-m live_debug->pc_reg_idx == 15");
+
+    /* riscv32 arch registration and live_debug */
+    const MkdbgArch *rv = mkdbg_arch_find("riscv32");
+    CHECK(rv != NULL, "mkdbg_arch_find(\"riscv32\") != NULL");
+    CHECK(rv != NULL && strcmp(rv->name, "riscv32") == 0,
+          "riscv32 arch->name == \"riscv32\"");
+    CHECK(rv != NULL && rv->live_debug != NULL,
+          "riscv32 has live_debug descriptor");
+    CHECK(rv != NULL && rv->live_debug != NULL && rv->live_debug->nregs == 33,
+          "riscv32 live_debug->nregs == 33");
+    CHECK(rv != NULL && rv->live_debug != NULL && rv->live_debug->pc_reg_idx == 32,
+          "riscv32 live_debug->pc_reg_idx == 32");
+
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- Extends `MkdbgArch` with an `ArchLiveDebug` descriptor (`nregs`, `pc_reg_idx`, `sp_reg_idx`, `reg_names[]`) so the live debug layer is no longer Cortex-M-only
- Adds `arch/riscv32.c`: 33-register RISC-V 32-bit plugin (x0-x31 + pc)
- `debug_session_open()` now takes a `const MkdbgArch *arch` parameter; exposes `nregs`/`reg_name`/`pc_reg` accessors
- `debug_cli` and `debug_tui` replace all hardcoded `[15]`/`reg_name()`/`NREGS=17` with arch accessor calls
- `--arch <name>` flag in `mkdbg debug` selects the architecture (default: `cortex-m`)
- `arch_test` extended with 8 new checks verifying live_debug descriptors for both archs (17/17 pass)

## Test plan

- [x] `ctest` — 2/2 suites, 17/17 assertions pass
- [x] `mkdbg debug --arch cortex-m` — existing behavior unchanged (17 regs, PC at index 15)
- [x] `mkdbg debug --arch riscv32` — 33-reg `g` response parsed, reg names `x0`-`x31`/`pc` displayed
- [x] `mkdbg debug --arch unknown` — dies with "arch 'unknown' does not support live debug"