### PR TITLE
feat(pr13): add ELF .symtab symbol lookup — enable break <symbol>

### DIFF
--- a/src/debug_cli.c
+++ b/src/debug_cli.c
@@ -126,9 +126,18 @@ static void trim_eol(char *s)
 
 static void do_break(DebugSession *s, const char *args)
 {
-    if (!*args) { printf("usage: break 0x<addr>\n"); return; }
+    if (!*args) { printf("usage: break 0x<addr> | break <symbol>\n"); return; }
 
-    uint32_t addr = parse_addr(args);
+    uint32_t addr;
+    if (args[0] == '0' && (args[1] == 'x' || args[1] == 'X')) {
+        addr = parse_addr(args);
+    } else if (s_dbi && dwarf_sym_to_addr(s_dbi, args, &addr) == 0) {
+        printf("(symbol '%s' = 0x%08x)\n", args, addr);
+    } else if (!s_dbi) {
+        printf("error: pass --elf to use symbol names\n"); return;
+    } else {
+        printf("error: symbol '%s' not found in ELF\n", args); return;
+    }
     if (debug_session_set_hw_breakpoint(s, addr) != WIRE_OK) {
         printf("error: could not set breakpoint (no free FPB comparator?)\n");
         return;
@@ -210,6 +219,7 @@ static void print_help(void)
     printf(
         "Commands:\n"
         "  break 0x<addr>      set hardware breakpoint (FPBv1)\n"
+        "  break <symbol>      set breakpoint at named function (requires --elf)\n"
         "  clear <id>          clear breakpoint by number\n"
         "  continue  (c)       resume execution; wait for next halt\n"
         "  step      (s)       single-step one instruction\n"

--- a/src/debug_tui.c
+++ b/src/debug_tui.c
@@ -444,11 +444,17 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             redraw(s, dbi);
 
         } else if (ev.ch == 'b') {
-            char inp[32] = "";
-            if (tui_prompt(y_hint, w, "break addr> 0x", inp, sizeof(inp)) == 0
+            char inp[64] = "";
+            if (tui_prompt(y_hint, w, "break> ", inp, sizeof(inp)) == 0
                     && inp[0]) {
-                uint32_t addr = (uint32_t)strtoul(inp, NULL, 16);
-                tui_bp_add(s, addr);
+                uint32_t addr = 0;
+                if ((inp[0] == '0' && (inp[1] == 'x' || inp[1] == 'X')) ||
+                    (inp[0] >= '0' && inp[0] <= '9')) {
+                    addr = (uint32_t)strtoul(inp, NULL, 16);
+                } else if (dbi) {
+                    dwarf_sym_to_addr(dbi, inp, &addr);
+                }
+                if (addr) tui_bp_add(s, addr);
             }
             redraw(s, dbi);
 

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -60,6 +60,11 @@ struct DwarfDBI {
     char    **files;       /* heap-allocated resolved paths */
     size_t    nfiles;
     size_t    files_cap;
+    /* ELF symbol table (.symtab + .strtab) — pointers into elf_data */
+    const uint8_t *sym_data;   /* NULL if .symtab absent or stripped */
+    size_t         sym_count;  /* number of Elf32_Sym entries (16 bytes each) */
+    const uint8_t *str_data;   /* .strtab string table */
+    size_t         str_size;
 };
 
 /* ── Little-endian readers ───────────────────────────────────────────────── */
@@ -502,6 +507,19 @@ DwarfDBI *dwarf_open(const char *elf_path)
     if (dbi->nrows > 0)
         qsort(dbi->rows, dbi->nrows, sizeof(DwarfRow), row_cmp);
 
+    /* Optional: ELF symbol table for name→address lookups (e.g. break main).
+     * Failure here is non-fatal — dwarf_sym_to_addr() will return -1. */
+    const uint8_t *sym_p = NULL; size_t sym_sz = 0;
+    const uint8_t *str_p = NULL; size_t str_sz = 0;
+    if (find_elf_section(data, size, ".symtab", &sym_p, &sym_sz) == 0 &&
+        find_elf_section(data, size, ".strtab", &str_p, &str_sz) == 0 &&
+        sym_sz % 16 == 0) {
+        dbi->sym_data  = sym_p;
+        dbi->sym_count = sym_sz / 16;
+        dbi->str_data  = str_p;
+        dbi->str_size  = str_sz;
+    }
+
     return dbi;
 }
 
@@ -538,4 +556,30 @@ int dwarf_pc_to_location(DwarfDBI *dbi, uint32_t pc, DwarfLocation *out)
     out->line   = dbi->rows[idx].line;
     out->column = dbi->rows[idx].column;
     return 0;
+}
+
+int dwarf_sym_to_addr(DwarfDBI *dbi, const char *name, uint32_t *addr)
+{
+    if (!dbi || !dbi->sym_data || !name || !addr) return -1;
+    /* Walk Elf32_Sym entries (16 bytes each):
+     *   offset  0: st_name  (uint32_t) — index into .strtab
+     *   offset  4: st_value (uint32_t) — symbol address
+     *   offset  8: st_size  (uint32_t)
+     *   offset 12: st_info  (uint8_t)  — bits[3:0]=type; STT_FUNC=2
+     *   offset 13: st_other (uint8_t)
+     *   offset 14: st_shndx (uint16_t)
+     */
+    for (size_t i = 0; i < dbi->sym_count; i++) {
+        const uint8_t *e      = dbi->sym_data + i * 16;
+        uint32_t       st_nm  = le32(e + 0);
+        uint32_t       st_val = le32(e + 4);
+        uint8_t        st_inf = e[12];
+        if ((st_inf & 0xfu) != 2u) continue;           /* not STT_FUNC */
+        if (st_nm >= (uint32_t)dbi->str_size) continue;
+        if (strcmp((const char *)dbi->str_data + st_nm, name) == 0) {
+            *addr = st_val;
+            return 0;
+        }
+    }
+    return -1;
 }

--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -34,4 +34,10 @@ void dwarf_close(DwarfDBI *dbi);
  *         -1  on internal error. */
 int dwarf_pc_to_location(DwarfDBI *dbi, uint32_t pc, DwarfLocation *out);
 
+/* Look up a function symbol by name in the ELF .symtab.
+ * Requires a non-stripped ELF (normal for firmware .elf files).
+ * Returns  0  and fills *addr on success,
+ *         -1  if not found or no symbol table present. */
+int dwarf_sym_to_addr(DwarfDBI *dbi, const char *name, uint32_t *addr);
+
 #endif /* DWARF_H */


### PR DESCRIPTION
Extend DwarfDBI with .symtab/.strtab fields parsed in dwarf_open(). Add dwarf_sym_to_addr() to resolve function names to addresses. debug_cli do_break() and debug_tui b-key both accept either 0x<addr> or a bare function name (e.g. break main) when --elf is provided.