### PR TITLE
feat(pr14): add DWT hardware watchpoints + rename watch→display

### DIFF
--- a/src/debug_cli.c
+++ b/src/debug_cli.c
@@ -34,6 +34,45 @@ static Breakpoint s_bp[BP_MAX];
 static int        s_bp_count  = 0;
 static int        s_bp_nextid = 1;
 
+/* ── Watchpoint list (DWT) ───────────────────────────────────────────────── */
+
+#define WP_MAX 4  /* DWT comparator hardware limit */
+
+typedef struct { int id; uint32_t addr; WatchpointType type; } Watchpoint;
+
+static Watchpoint s_wp[WP_MAX];
+static int        s_wp_count  = 0;
+static int        s_wp_nextid = 1;
+
+static int wp_add(uint32_t addr, WatchpointType type)
+{
+    if (s_wp_count >= WP_MAX) return -1;
+    s_wp[s_wp_count].id   = s_wp_nextid++;
+    s_wp[s_wp_count].addr = addr;
+    s_wp[s_wp_count].type = type;
+    s_wp_count++;
+    return s_wp[s_wp_count - 1].id;
+}
+
+static int wp_remove(int id, uint32_t *addr_out)
+{
+    for (int i = 0; i < s_wp_count; i++) {
+        if (s_wp[i].id == id) {
+            *addr_out = s_wp[i].addr;
+            s_wp[i]   = s_wp[--s_wp_count];
+            return 0;
+        }
+    }
+    return -1;
+}
+
+/* ── Memory display list ─────────────────────────────────────────────────── */
+
+#define DISPLAY_MAX 8
+
+static uint32_t s_display[DISPLAY_MAX];
+static int      s_ndisplay = 0;
+
 static int bp_add(uint32_t addr)
 {
     if (s_bp_count >= BP_MAX) return -1;
@@ -214,20 +253,92 @@ static void do_info_breakpoints(void)
         printf("%-4d 0x%08x\n", s_bp[i].id, s_bp[i].addr);
 }
 
+static void do_watch(DebugSession *s, const char *args, WatchpointType type)
+{
+    if (!*args) {
+        printf("usage: watch/rwatch/awatch 0x<addr>\n"); return;
+    }
+    uint32_t addr = parse_addr(args);
+    if (debug_session_set_watchpoint(s, addr, 1, type) != WIRE_OK) {
+        printf("error: could not set watchpoint (no free DWT comparator?)\n");
+        return;
+    }
+    int id = wp_add(addr, type);
+    if (id < 0) {
+        debug_session_clear_watchpoint(s, addr);
+        printf("error: watchpoint list full\n");
+        return;
+    }
+    const char *tname = (type == WATCHPOINT_WRITE)  ? "write"  :
+                        (type == WATCHPOINT_READ)   ? "read"   : "access";
+    printf("Watchpoint %d at 0x%08x (%s)\n", id, addr, tname);
+}
+
+static void do_delete_watch(DebugSession *s, const char *args)
+{
+    if (!*args) { printf("usage: delete watch <id>\n"); return; }
+    int id = atoi(args);
+    uint32_t addr;
+    if (wp_remove(id, &addr) != 0) {
+        printf("error: no watchpoint %d\n", id); return;
+    }
+    if (debug_session_clear_watchpoint(s, addr) != WIRE_OK)
+        printf("warning: target returned error clearing watchpoint\n");
+    else
+        printf("Watchpoint %d (0x%08x) cleared.\n", id, addr);
+}
+
+static void do_info_watchpoints(void)
+{
+    if (s_wp_count == 0) { printf("No watchpoints.\n"); return; }
+    printf("Num  Address     Type\n");
+    for (int i = 0; i < s_wp_count; i++) {
+        const char *t = (s_wp[i].type == WATCHPOINT_WRITE)  ? "write"  :
+                        (s_wp[i].type == WATCHPOINT_READ)   ? "read"   : "access";
+        printf("%-4d 0x%08x  %s\n", s_wp[i].id, s_wp[i].addr, t);
+    }
+}
+
+static void do_display(const char *args)
+{
+    if (!*args) { printf("usage: display 0x<addr>\n"); return; }
+    if (s_ndisplay >= DISPLAY_MAX) { printf("error: display list full\n"); return; }
+    s_display[s_ndisplay++] = parse_addr(args);
+    printf("display %d: 0x%08x\n", s_ndisplay, s_display[s_ndisplay - 1]);
+}
+
+static void do_undisplay(const char *args)
+{
+    if (!*args) { printf("usage: undisplay <id>\n"); return; }
+    int id = atoi(args) - 1;
+    if (id < 0 || id >= s_ndisplay) { printf("error: no display %d\n", id + 1); return; }
+    for (int i = id; i < s_ndisplay - 1; i++) s_display[i] = s_display[i + 1];
+    s_ndisplay--;
+    printf("display %d removed\n", id + 1);
+}
+
 static void print_help(void)
 {
     printf(
         "Commands:\n"
-        "  break 0x<addr>      set hardware breakpoint (FPBv1)\n"
-        "  break <symbol>      set breakpoint at named function (requires --elf)\n"
-        "  clear <id>          clear breakpoint by number\n"
-        "  continue  (c)       resume execution; wait for next halt\n"
-        "  step      (s)       single-step one instruction\n"
-        "  regs                print all CPU registers\n"
-        "  mem 0x<addr> [len]  hexdump memory (default 16 bytes, max 256)\n"
-        "  info breakpoints    list active breakpoints\n"
-        "  tui                 TUI mode (PR 11)\n"
-        "  quit      (q)       resume MCU and exit\n"
+        "  break 0x<addr>           set hardware breakpoint (FPBv1)\n"
+        "  break <symbol>           set breakpoint at named function (requires --elf)\n"
+        "  clear <id>               clear breakpoint by number\n"
+        "  watch 0x<addr>           DWT write watchpoint\n"
+        "  rwatch 0x<addr>          DWT read watchpoint\n"
+        "  awatch 0x<addr>          DWT read+write watchpoint\n"
+        "  delete watch <id>        clear DWT watchpoint by number\n"
+        "  display 0x<addr>         add memory address to display list\n"
+        "  undisplay <id>           remove from display list\n"
+        "  continue  (c)            resume execution; wait for next halt\n"
+        "  step      (s)            single-step one instruction\n"
+        "  regs                     print all CPU registers\n"
+        "  mem 0x<addr> [len]       hexdump memory (default 16 bytes, max 256)\n"
+        "  info breakpoints         list active breakpoints\n"
+        "  info watchpoints         list active DWT watchpoints\n"
+        "  info display             list memory display addresses\n"
+        "  tui                      TUI mode\n"
+        "  quit      (q)            resume MCU and exit\n"
     );
 }
 
@@ -262,6 +373,9 @@ int cmd_debug(const DebugOptions *opts)
     /* Reset state for this session */
     s_bp_count  = 0;
     s_bp_nextid = 1;
+    s_wp_count  = 0;
+    s_wp_nextid = 1;
+    s_ndisplay  = 0;
 
     char line[256];
     for (;;) {
@@ -292,11 +406,31 @@ int cmd_debug(const DebugOptions *opts)
             do_regs(s);
         } else if (strcmp(cmd, "mem") == 0) {
             do_mem(s, args);
+        } else if (strcmp(cmd, "watch") == 0) {
+            do_watch(s, args, WATCHPOINT_WRITE);
+        } else if (strcmp(cmd, "rwatch") == 0) {
+            do_watch(s, args, WATCHPOINT_READ);
+        } else if (strcmp(cmd, "awatch") == 0) {
+            do_watch(s, args, WATCHPOINT_ACCESS);
+        } else if (strcmp(cmd, "delete") == 0) {
+            char sub[16];
+            const char *rest = split_token(args, sub, sizeof(sub));
+            if (strcmp(sub, "watch") == 0) do_delete_watch(s, rest);
+            else printf("delete: unknown subcommand '%s'\n", sub);
+        } else if (strcmp(cmd, "display") == 0) {
+            do_display(args);
+        } else if (strcmp(cmd, "undisplay") == 0) {
+            do_undisplay(args);
         } else if (strcmp(cmd, "info") == 0) {
             char sub[32];
             split_token(args, sub, sizeof(sub));
             if (strcmp(sub, "breakpoints") == 0) do_info_breakpoints();
-            else printf("info: unknown subcommand '%s'\n", sub);
+            else if (strcmp(sub, "watchpoints") == 0) do_info_watchpoints();
+            else if (strcmp(sub, "display") == 0) {
+                if (s_ndisplay == 0) printf("No display addresses.\n");
+                else for (int i = 0; i < s_ndisplay; i++)
+                    printf("%d: 0x%08x\n", i + 1, s_display[i]);
+            } else printf("info: unknown subcommand '%s'\n", sub);
         } else if (strcmp(cmd, "tui") == 0) {
             int ret = debug_tui_run(s, s_dbi);
             if (ret == TUI_QUIT) {

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -124,6 +124,34 @@ int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr)
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
 
+/* ── DWT Hardware Watchpoints ────────────────────────────────────────────── */
+
+int debug_session_set_watchpoint(DebugSession *s, uint32_t addr,
+                                  uint32_t len, WatchpointType type)
+{
+    char cmd[32];
+    snprintf(cmd, sizeof(cmd), "Z%d,%x,%x", (int)type, addr, len ? len : 1);
+
+    char resp[16];
+    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    if (rc != WIRE_OK) return rc;
+    return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr)
+{
+    /* Try all three types (write/read/access) — firmware matches by address. */
+    char cmd[32];
+    char resp[16];
+    int types[3] = { WATCHPOINT_WRITE, WATCHPOINT_READ, WATCHPOINT_ACCESS };
+    for (int i = 0; i < 3; i++) {
+        snprintf(cmd, sizeof(cmd), "z%d,%x,1", types[i], addr);
+        int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+        if (rc == WIRE_OK && strcmp(resp, "OK") == 0) return WIRE_OK;
+    }
+    return WIRE_ERR_IO;
+}
+
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
 int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS])

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -55,6 +55,24 @@ int debug_session_set_hw_breakpoint(DebugSession *s, uint32_t addr);
  * Returns WIRE_OK, or WIRE_ERR_IO if addr was not an active breakpoint. */
 int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr);
 
+/* ── DWT Hardware Watchpoints ────────────────────────────────────────────── */
+
+/* Watchpoint type matches GDB RSP Z-packet type codes. */
+typedef enum {
+    WATCHPOINT_WRITE  = 2,  /* Z2 — halt on write to addr */
+    WATCHPOINT_READ   = 3,  /* Z3 — halt on read from addr */
+    WATCHPOINT_ACCESS = 4,  /* Z4 — halt on read or write */
+} WatchpointType;
+
+/* Set a DWT hardware watchpoint at addr (len bytes, exact match when len=1).
+ * Returns WIRE_OK, or WIRE_ERR_IO if all DWT comparators are occupied. */
+int debug_session_set_watchpoint(DebugSession *s, uint32_t addr,
+                                  uint32_t len, WatchpointType type);
+
+/* Clear DWT watchpoint at addr.
+ * Returns WIRE_OK, or WIRE_ERR_IO if addr was not an active watchpoint. */
+int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr);
+
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
 /* Read all CPU registers into regs[DEBUG_SESSION_NREGS].

--- a/src/debug_tui.c
+++ b/src/debug_tui.c
@@ -34,19 +34,25 @@
 
 #define REG_ROWS     8    /* register panel content rows (r0-r12 + sp/lr/pc/xpsr) */
 #define CTX_HALF     4    /* source context: ±4 lines around PC = 9 visible lines */
-#define MAX_WATCHES  4
+#define MAX_DISPLAY  4
+#define TUI_WP_MAX   4
 
 /* ── Local state ─────────────────────────────────────────────────────────── */
 
 #define TUI_BP_MAX 8
 typedef struct { int id; uint32_t addr; } TuiBP;
+typedef struct { int id; uint32_t addr; WatchpointType type; } TuiWP;
 
 static TuiBP    s_bp[TUI_BP_MAX];
 static int      s_nbp      = 0;
 static int      s_bp_next  = 1;
 
-static uint32_t s_watches[MAX_WATCHES];
-static int      s_nwatches = 0;
+static TuiWP    s_wpts[TUI_WP_MAX];
+static int      s_nwpts    = 0;
+static int      s_wp_next  = 1;
+
+static uint32_t s_display[MAX_DISPLAY];
+static int      s_ndisplay = 0;
 
 static uint32_t s_regs[DEBUG_SESSION_NREGS];
 static int      s_regs_ok  = 0;
@@ -187,7 +193,7 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
     hline(y0, 12, split);
     bchar(split, y0, "\xe2\x94\xac");                  /* ┬ */
     tb_print(split + 1, y0, TB_CYAN, TB_DEFAULT,
-             "\xe2\x94\x80 Breakpoints ");
+             "\xe2\x94\x80 BP / WP ");
     hline(y0, split + 14, w - 1);
     bchar(w - 1, y0, "\xe2\x94\xa4");                  /* ┤ */
 
@@ -219,7 +225,7 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
 
         bchar(split, y0 + 1 + r, "\xe2\x94\x82");      /* │ middle */
 
-        /* ── Breakpoints (right half) ── */
+        /* ── Breakpoints + Watchpoints (right half) ── */
         if (r < s_nbp) {
             DwarfLocation loc;
             char loc_str[64] = "";
@@ -229,9 +235,17 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
                 snprintf(loc_str, sizeof(loc_str), " %s:%d", base, loc.line);
             }
             tb_printf(split + 1, y0 + 1 + r, TB_DEFAULT, TB_DEFAULT,
-                      " #%-2d 0x%08x%-*s",
+                      " #%-2d 0x%08x (BP)%-*s",
                       s_bp[r].id, s_bp[r].addr,
-                      bp_content_w - 18, loc_str);
+                      bp_content_w - 22, loc_str);
+        } else if (r - s_nbp < s_nwpts) {
+            int wi = r - s_nbp;
+            const char *t = (s_wpts[wi].type == WATCHPOINT_WRITE)  ? "W " :
+                            (s_wpts[wi].type == WATCHPOINT_READ)   ? "R " : "RW";
+            tb_printf(split + 1, y0 + 1 + r, TB_YELLOW, TB_DEFAULT,
+                      " W%-2d 0x%08x (%s)%-*s",
+                      s_wpts[wi].id, s_wpts[wi].addr, t,
+                      bp_content_w - 24, "");
         }
         (void)bp_content_w;
 
@@ -255,9 +269,9 @@ static void draw_mem(int y0, int h, int w, DebugSession *s)
 
     for (int r = 0; r < h; r++) {
         bchar(0, y0 + 1 + r, "\xe2\x94\x82");
-        if (r < s_nwatches) {
+        if (r < s_ndisplay) {
             uint8_t buf[16];
-            if (debug_session_read_mem(s, s_watches[r], 16, buf) == WIRE_OK) {
+            if (debug_session_read_mem(s, s_display[r], 16, buf) == WIRE_OK) {
                 char hex[64];
                 int pos = 0;
                 for (int i = 0; i < 16; i++) {
@@ -266,10 +280,10 @@ static void draw_mem(int y0, int h, int w, DebugSession *s)
                 }
                 hex[pos > 0 ? pos - 1 : 0] = '\0';
                 tb_printf(2, y0 + 1 + r, TB_DEFAULT, TB_DEFAULT,
-                          "0x%08x: %s", s_watches[r], hex);
+                          "0x%08x: %s", s_display[r], hex);
             } else {
                 tb_printf(2, y0 + 1 + r, TB_RED, TB_DEFAULT,
-                          "0x%08x: <read error>", s_watches[r]);
+                          "0x%08x: <read error>", s_display[r]);
             }
         }
         bchar(w - 1, y0 + 1 + r, "\xe2\x94\x82");
@@ -285,7 +299,7 @@ static void draw_bottom(int y_border, int y_hint, int w)
     bchar(w - 1, y_border, "\xe2\x94\x98");            /* ┘ */
 
     tb_print(0, y_hint, TB_YELLOW, TB_DEFAULT,
-             "[s]tep [c]ontinue [b]reak [d]el [m]em [t]cli [q]uit");
+             "[s]tep [c]ontinue [b]reak [d]el [w]atch [m]em [t]cli [q]uit");
 }
 
 /* ── Status bar (replaces hint bar during blocking ops) ──────────────────── */
@@ -308,7 +322,7 @@ static void redraw(DebugSession *s, DwarfDBI *dbi)
     tb_clear();
 
     /* Compute panel heights */
-    int mem_h  = (s_nwatches > 0) ? s_nwatches : 1;
+    int mem_h  = (s_ndisplay > 0) ? s_ndisplay : 1;
     int src_h  = h - REG_ROWS - mem_h - 6;
     /* 6 = top_border(1) + reg_sep(1) + mem_sep(1) + bottom_border(1) + hint(1) + 1 spare */
     if (src_h < 3) src_h = 3;
@@ -396,7 +410,9 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
     /* Reset local state */
     s_nbp      = 0;
     s_bp_next  = 1;
-    s_nwatches = 0;
+    s_nwpts    = 0;
+    s_wp_next  = 1;
+    s_ndisplay = 0;
     s_regs_ok  = 0;
     s_pc       = 0;
 
@@ -467,11 +483,28 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             redraw(s, dbi);
 
         } else if (ev.ch == 'm') {
-            if (s_nwatches < MAX_WATCHES) {
+            if (s_ndisplay < MAX_DISPLAY) {
+                char inp[32] = "";
+                if (tui_prompt(y_hint, w, "display addr> 0x", inp, sizeof(inp)) == 0
+                        && inp[0]) {
+                    s_display[s_ndisplay++] = (uint32_t)strtoul(inp, NULL, 16);
+                }
+            }
+            redraw(s, dbi);
+
+        } else if (ev.ch == 'w') {
+            if (s_nwpts < TUI_WP_MAX) {
                 char inp[32] = "";
                 if (tui_prompt(y_hint, w, "watch addr> 0x", inp, sizeof(inp)) == 0
                         && inp[0]) {
-                    s_watches[s_nwatches++] = (uint32_t)strtoul(inp, NULL, 16);
+                    uint32_t addr = (uint32_t)strtoul(inp, NULL, 16);
+                    if (addr && debug_session_set_watchpoint(
+                            s, addr, 1, WATCHPOINT_WRITE) == WIRE_OK) {
+                        s_wpts[s_nwpts].id   = s_wp_next++;
+                        s_wpts[s_nwpts].addr = addr;
+                        s_wpts[s_nwpts].type = WATCHPOINT_WRITE;
+                        s_nwpts++;
+                    }
                 }
             }
             redraw(s, dbi);


### PR DESCRIPTION
Target: wire_rsp.c adds Z2/z2/Z3/z3/Z4/z4 DWT comparator handlers Host: debug_session adds set/clear_watchpoint() via RSP Z2/Z3/Z4 CLI: watch/rwatch/awatch commands, delete watch <id>, info watchpoints
     'watch' (memory display) renamed to 'display'/'undisplay'
TUI: 'w' key sets DWT write watchpoint; BP/WP panel shows both types