### PR TITLE
feat(arch): arch-aware debug session + RISC-V 32-bit plugin (PR 15)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(mkdbg-native
   src/dwarf.c
   src/termbox2_impl.c
   arch/cortex_m.c
+  arch/riscv32.c
   arch/arch_registry.c
   $<TARGET_OBJECTS:seam_lib>
   $<TARGET_OBJECTS:wire_crash_lib>
@@ -145,6 +146,7 @@ set_tests_properties(seam_analyze_kdi_cascade PROPERTIES
 add_executable(arch_test
   tests/arch_test.c
   arch/cortex_m.c
+  arch/riscv32.c
   arch/arch_registry.c
 )
 target_compile_options(arch_test PRIVATE -Wall -Wextra -Werror -O2)

--- a/arch/arch.h
+++ b/arch/arch.h
@@ -21,7 +21,16 @@
 /* MkdbgCrashReport aliases WireCrashReport for the arch layer. */
 typedef WireCrashReport MkdbgCrashReport;
 
+/* Live-debug register layout for a given arch.
+ * Used by debug_session and debug_tui to avoid hardcoding Cortex-M specifics. */
 typedef struct {
+    int         nregs;         /* total registers returned by RSP 'g' command */
+    int         pc_reg_idx;    /* index of PC in the register array */
+    int         sp_reg_idx;    /* index of SP in the register array */
+    const char *reg_names[64]; /* register names, NULL-terminated */
+} ArchLiveDebug;
+
+typedef struct MkdbgArch {
     const char *name;  /* arch name matched by --arch flag, e.g. "cortex-m" */
 
     /*
@@ -34,6 +43,9 @@ typedef struct {
      * Returns 0 on success, -1 on error (bad length, parse failure, etc.).
      */
     int (*decode_crash)(const uint8_t *raw, size_t len, MkdbgCrashReport *out);
+
+    /* Live debug register layout.  NULL if the arch doesn't support live debug. */
+    const ArchLiveDebug *live_debug;
 } MkdbgArch;
 
 /* Returns the registered arch whose name matches (case-sensitive), or NULL. */

--- a/arch/arch_registry.c
+++ b/arch/arch_registry.c
@@ -10,9 +10,11 @@
 #include <string.h>
 
 extern const MkdbgArch cortex_m_arch;
+extern const MkdbgArch riscv32_arch;
 
 static const MkdbgArch *arches[] = {
     &cortex_m_arch,
+    &riscv32_arch,
     NULL,
 };
 

--- a/arch/cortex_m.c
+++ b/arch/cortex_m.c
@@ -241,9 +241,21 @@ static int cortex_m_decode_crash(const uint8_t *raw, size_t len,
 
 /* ── exported arch descriptor ────────────────────────────────────────────── */
 
+static const ArchLiveDebug cortex_m_live = {
+    .nregs       = 17,
+    .pc_reg_idx  = 15,
+    .sp_reg_idx  = 13,
+    .reg_names   = {
+        "r0","r1","r2","r3","r4","r5","r6","r7",
+        "r8","r9","r10","r11","r12","sp","lr","pc","xpsr",
+        NULL
+    },
+};
+
 const MkdbgArch cortex_m_arch = {
     .name         = "cortex-m",
     .decode_crash = cortex_m_decode_crash,
+    .live_debug   = &cortex_m_live,
 };
 
 /* suppress "unused function" warnings for parse_registers / parse_halt_signal

--- a/arch/riscv32.c
+++ b/arch/riscv32.c
@@ -1,0 +1,46 @@
+/* arch/riscv32.c — RISC-V 32-bit arch plugin
+ *
+ * Live debug register layout:
+ *   x0-x31 (32 general-purpose registers) + pc = 33 registers.
+ *   RSP 'g' returns 33 × 8 hex chars = 264 chars, little-endian.
+ *
+ *   Notable aliases: x1=ra, x2=sp, x3=gp, x4=tp, x5-x7=t0-t2,
+ *   x8=s0/fp, x9=s1, x10-x11=a0-a1, x12-x17=a2-a7, x18-x27=s2-s11,
+ *   x28-x31=t3-t6, x32=pc.
+ *
+ * decode_crash: not yet implemented (no wire firmware port for RISC-V).
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "arch.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+static int riscv32_decode_crash(const uint8_t *raw, size_t len,
+                                 MkdbgCrashReport *out)
+{
+    (void)raw; (void)len; (void)out;
+    return -1;  /* not yet implemented */
+}
+
+static const ArchLiveDebug riscv32_live = {
+    .nregs      = 33,
+    .pc_reg_idx = 32,
+    .sp_reg_idx = 2,   /* x2 = sp */
+    .reg_names  = {
+        "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
+        "x8", "x9", "x10","x11","x12","x13","x14","x15",
+        "x16","x17","x18","x19","x20","x21","x22","x23",
+        "x24","x25","x26","x27","x28","x29","x30","x31",
+        "pc",
+        NULL
+    },
+};
+
+const MkdbgArch riscv32_arch = {
+    .name         = "riscv32",
+    .decode_crash = riscv32_decode_crash,
+    .live_debug   = &riscv32_live,
+};

--- a/src/debug_cli.c
+++ b/src/debug_cli.c
@@ -19,6 +19,7 @@
 #include "debug_tui.h"
 #include "dwarf.h"
 #include "wire_host.h"
+#include "arch.h"
 
 /* ── Session-scoped DWARF handle (NULL if no --elf provided) ─────────────── */
 
@@ -107,22 +108,15 @@ static const char *signal_name(int sig)
     }
 }
 
-static const char *reg_name(int i)
-{
-    static const char *names[17] = {
-        "r0","r1","r2","r3","r4","r5","r6","r7",
-        "r8","r9","r10","r11","r12","sp","lr","pc","xpsr"
-    };
-    return (i >= 0 && i < 17) ? names[i] : "??";
-}
+/* reg_name is now delegated to debug_session_reg_name(s, i) at call sites */
 
 static void print_halt(DebugSession *s)
 {
     int sig = debug_session_last_signal(s);
     printf("Halted.  signal=%d (%s)", sig, signal_name(sig));
-    uint32_t regs[DEBUG_SESSION_NREGS];
+    uint32_t regs[DEBUG_SESSION_MAX_REGS];
     if (debug_session_read_regs(s, regs) == WIRE_OK) {
-        uint32_t pc = regs[15];
+        uint32_t pc = regs[debug_session_pc_reg(s)];
         printf("  pc=0x%08x", pc);
         if (s_dbi) {
             DwarfLocation loc;
@@ -208,19 +202,16 @@ static void do_clear(DebugSession *s, const char *args)
 
 static void do_regs(DebugSession *s)
 {
-    uint32_t regs[DEBUG_SESSION_NREGS];
+    uint32_t regs[DEBUG_SESSION_MAX_REGS];
     if (debug_session_read_regs(s, regs) != WIRE_OK) {
         printf("error: failed to read registers\n");
         return;
     }
-    /* r0–r12: four per row */
-    for (int i = 0; i <= 12; i++) {
-        printf("%-4s 0x%08x", reg_name(i), regs[i]);
-        printf(((i % 4) == 3 || i == 12) ? "\n" : "   ");
+    int nregs = debug_session_nregs(s);
+    for (int i = 0; i < nregs; i++) {
+        printf("%-6s 0x%08x", debug_session_reg_name(s, i), regs[i]);
+        printf(((i % 4) == 3 || i == nregs - 1) ? "\n" : "   ");
     }
-    printf("sp   0x%08x   lr   0x%08x   pc   0x%08x\n",
-           regs[13], regs[14], regs[15]);
-    printf("xpsr 0x%08x\n", regs[16]);
 }
 
 static void do_mem(DebugSession *s, const char *args)
@@ -352,7 +343,12 @@ int cmd_debug(const DebugOptions *opts)
     if (!port || !*port)
         die("debug requires --port; e.g. mkdbg debug --port /dev/ttyUSB0");
 
-    DebugSession *s = debug_session_open(port, baud);
+    const char     *arch_name = opts->arch ? opts->arch : "cortex-m";
+    const MkdbgArch *arch     = mkdbg_arch_find(arch_name);
+    if (!arch || !arch->live_debug)
+        die("arch '%s' does not support live debug", arch_name);
+
+    DebugSession *s = debug_session_open(port, baud, arch);
     if (!s) return 1;
 
     printf("mkdbg live debug  port=%s  baud=%d\n", port, baud);

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -4,6 +4,7 @@
  */
 
 #include "debug_session.h"
+#include "arch.h"
 #include "wire_host.h"
 
 #include <stdio.h>
@@ -14,8 +15,9 @@
 /* ── Internal state ──────────────────────────────────────────────────────── */
 
 struct DebugSession {
-    int fd;           /* serial port file descriptor */
-    int last_signal;  /* GDB signal from most recent stop reply */
+    int              fd;           /* serial port file descriptor */
+    int              last_signal;  /* GDB signal from most recent stop reply */
+    const MkdbgArch *arch;         /* active architecture (live_debug guaranteed non-NULL) */
 };
 
 /* ── Hex helpers (local) ─────────────────────────────────────────────────── */
@@ -40,7 +42,8 @@ static int parse_stop_signal(const char *reply)
 
 /* ── Lifecycle ───────────────────────────────────────────────────────────── */
 
-DebugSession *debug_session_open(const char *port, int baud)
+DebugSession *debug_session_open(const char *port, int baud,
+                                  const MkdbgArch *arch)
 {
     int fd = wire_serial_open(port, baud);
     if (fd < 0) return NULL;
@@ -52,6 +55,7 @@ DebugSession *debug_session_open(const char *port, int baud)
     }
     s->fd          = fd;
     s->last_signal = 0;
+    s->arch        = arch;
     return s;
 }
 
@@ -154,15 +158,16 @@ int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr)
 
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
-int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS])
+int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_MAX_REGS])
 {
-    /* RSP 'g' response: 17 registers × 8 hex chars = 136 chars, little-endian. */
-    char resp[256];
+    int nregs = s->arch->live_debug->nregs;
+    /* RSP 'g': nregs registers × 8 hex chars each, little-endian. */
+    char resp[DEBUG_SESSION_MAX_REGS * 8 + 4];
     int rc = rsp_transaction(s->fd, "g", resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     if (resp[0] == 'E') return WIRE_ERR_IO;
 
-    for (int i = 0; i < DEBUG_SESSION_NREGS; i++) {
+    for (int i = 0; i < nregs; i++) {
         const char *p = resp + i * 8;
         uint32_t v = 0;
         for (int b = 0; b < 4; b++) {
@@ -196,6 +201,24 @@ int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *
         out[i] = (uint8_t)((hi << 4) | lo);
     }
     return WIRE_OK;
+}
+
+/* ── Arch metadata ───────────────────────────────────────────────────────── */
+
+int debug_session_nregs(const DebugSession *s)
+{
+    return s ? s->arch->live_debug->nregs : 0;
+}
+
+const char *debug_session_reg_name(const DebugSession *s, int i)
+{
+    if (!s || i < 0 || i >= s->arch->live_debug->nregs) return "??";
+    return s->arch->live_debug->reg_names[i];
+}
+
+int debug_session_pc_reg(const DebugSession *s)
+{
+    return s ? s->arch->live_debug->pc_reg_idx : 0;
 }
 
 /* ── Status ──────────────────────────────────────────────────────────────── */

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -15,18 +15,23 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* Forward-declare MkdbgArch to avoid circular includes. */
+typedef struct MkdbgArch MkdbgArch;
+
 /* Opaque session handle. */
 typedef struct DebugSession DebugSession;
 
-/* Number of Cortex-M registers returned by debug_session_read_regs().
- * Order: r0-r12, sp(r13), lr(r14), pc(r15), xpsr  — matches RSP 'g' layout. */
-#define DEBUG_SESSION_NREGS 17
+/* Maximum registers any supported arch can return from RSP 'g'.
+ * Cortex-M: 17.  RISC-V 32: 33.  Increase if a future arch needs more. */
+#define DEBUG_SESSION_MAX_REGS 64
 
 /* ── Lifecycle ───────────────────────────────────────────────────────────── */
 
 /* Open UART port and return a new session.  baud=0 for PTY (QEMU).
+ * arch must point to an MkdbgArch with a valid live_debug descriptor.
  * Returns NULL on error (error printed to stderr). */
-DebugSession *debug_session_open(const char *port, int baud);
+DebugSession *debug_session_open(const char *port, int baud,
+                                  const MkdbgArch *arch);
 
 /* Close UART and free the session. */
 void debug_session_close(DebugSession *s);
@@ -75,13 +80,25 @@ int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr);
 
 /* ── Register / memory inspection ───────────────────────────────────────── */
 
-/* Read all CPU registers into regs[DEBUG_SESSION_NREGS].
- * Indices: 0-12 = r0-r12, 13 = sp, 14 = lr, 15 = pc, 16 = xpsr. */
-int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_NREGS]);
+/* Read all CPU registers into regs[].  The number of registers is arch-dependent;
+ * use debug_session_nregs() to find out how many were written.
+ * regs must have room for at least DEBUG_SESSION_MAX_REGS elements. */
+int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_MAX_REGS]);
 
 /* Read len bytes from target address addr into out.
  * Returns WIRE_OK, or WIRE_ERR_IO if address is out of the allowed RAM range. */
 int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *out);
+
+/* ── Arch metadata ───────────────────────────────────────────────────────── */
+
+/* Number of registers returned by debug_session_read_regs() for this session. */
+int debug_session_nregs(const DebugSession *s);
+
+/* Register name at index i (e.g. "r0", "pc", "x2").  Returns "??" if out of range. */
+const char *debug_session_reg_name(const DebugSession *s, int i);
+
+/* Index of the PC register (e.g. 15 for Cortex-M, 32 for RISC-V). */
+int debug_session_pc_reg(const DebugSession *s);
 
 /* ── Status ──────────────────────────────────────────────────────────────── */
 

--- a/src/debug_tui.c
+++ b/src/debug_tui.c
@@ -54,7 +54,7 @@ static int      s_wp_next  = 1;
 static uint32_t s_display[MAX_DISPLAY];
 static int      s_ndisplay = 0;
 
-static uint32_t s_regs[DEBUG_SESSION_NREGS];
+static uint32_t s_regs[DEBUG_SESSION_MAX_REGS];
 static int      s_regs_ok  = 0;
 
 static uint32_t s_pc       = 0;
@@ -161,19 +161,10 @@ static void draw_source(int y0, int src_h, int w, DwarfDBI *dbi, uint32_t pc)
 
 /* ── Register/Breakpoint panel ───────────────────────────────────────────── */
 
-/* Register name at index 0-16 */
-static const char *rname(int i)
-{
-    static const char *n[] = {
-        "r0","r1","r2","r3","r4","r5","r6","r7",
-        "r8","r9","r10","r11","r12","sp","lr","pc","xpsr"
-    };
-    return (i >= 0 && i < 17) ? n[i] : "??";
-}
-
 /*
  * Register pairs displayed per row (left index, right index).
- * Rows: 0..REG_ROWS-1 = 8 rows.
+ * Rows: 0..REG_ROWS-1 = 8 rows.  Cortex-M layout; for other arches
+ * indices that exceed nregs are silently skipped.
  */
 static const int REG_PAIRS[REG_ROWS][2] = {
     {0, 8}, {1, 9}, {2, 10}, {3, 11}, {4, 12},
@@ -182,7 +173,7 @@ static const int REG_PAIRS[REG_ROWS][2] = {
     {6, 16},   /* r6, xpsr */
 };
 
-static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
+static void draw_reg_bp(int y0, int h, int w, DebugSession *s, DwarfDBI *dbi, uint32_t pc)
 {
     int split = w / 2;  /* column of the vertical separator ─ │ ─ */
 
@@ -204,24 +195,32 @@ static void draw_reg_bp(int y0, int h, int w, DwarfDBI *dbi, uint32_t pc)
         bchar(0, y0 + 1 + r, "\xe2\x94\x82");          /* │ left edge */
 
         /* ── Registers (left half) ── */
+        int nregs = debug_session_nregs(s);
+        int pc_reg = debug_session_pc_reg(s);
         if (r < REG_ROWS && s_regs_ok) {
             int li = REG_PAIRS[r][0];
             int ri = REG_PAIRS[r][1];
             /* highlight pc with bold */
             uintattr_t pc_fg = TB_WHITE | TB_BOLD;
             uintattr_t pc_bg = TB_BLUE;
-            uintattr_t lfg = (li == 15) ? pc_fg : TB_DEFAULT;
-            uintattr_t lbg = (li == 15) ? pc_bg : TB_DEFAULT;
-            uintattr_t rfg = (ri == 15) ? pc_fg : TB_DEFAULT;
-            uintattr_t rbg = (ri == 15) ? pc_bg : TB_DEFAULT;
+            uintattr_t lfg = (li == pc_reg) ? pc_fg : TB_DEFAULT;
+            uintattr_t lbg = (li == pc_reg) ? pc_bg : TB_DEFAULT;
+            uintattr_t rfg = (ri == pc_reg) ? pc_fg : TB_DEFAULT;
+            uintattr_t rbg = (ri == pc_reg) ? pc_bg : TB_DEFAULT;
             char lbuf[20], rbuf[20];
-            snprintf(lbuf, sizeof(lbuf), "%-4s 0x%08x", rname(li), s_regs[li]);
-            snprintf(rbuf, sizeof(rbuf), "%-4s 0x%08x", rname(ri), s_regs[ri]);
+            if (li < nregs)
+                snprintf(lbuf, sizeof(lbuf), "%-6s 0x%08x",
+                         debug_session_reg_name(s, li), s_regs[li]);
+            else lbuf[0] = '\0';
+            if (ri < nregs)
+                snprintf(rbuf, sizeof(rbuf), "%-6s 0x%08x",
+                         debug_session_reg_name(s, ri), s_regs[ri]);
+            else rbuf[0] = '\0';
             tb_printf(1, y0 + 1 + r, lfg, lbg, " %-*s", reg_content_w / 2, lbuf);
             tb_printf(1 + reg_content_w / 2 + 1, y0 + 1 + r, rfg, rbg,
                       " %-*s", reg_content_w / 2, rbuf);
         }
-        (void)reg_content_w;
+        (void)reg_content_w; (void)nregs; (void)pc_reg;
 
         bchar(split, y0 + 1 + r, "\xe2\x94\x82");      /* │ middle */
 
@@ -334,7 +333,7 @@ static void redraw(DebugSession *s, DwarfDBI *dbi)
     int y_hint     = y_bottom + 1;
 
     draw_source(y_src_top, src_h, w, dbi, s_pc);
-    draw_reg_bp(y_reg_sep, REG_ROWS, w, dbi, s_pc);
+    draw_reg_bp(y_reg_sep, REG_ROWS, w, s, dbi, s_pc);
     draw_mem(y_mem_sep, mem_h, w, s);
     draw_bottom(y_bottom, y_hint, w);
 
@@ -419,7 +418,7 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
     /* Read initial register state */
     if (debug_session_read_regs(s, s_regs) == WIRE_OK) {
         s_regs_ok = 1;
-        s_pc = s_regs[15];
+        s_pc = s_regs[debug_session_pc_reg(s)];
     }
 
     redraw(s, dbi);
@@ -446,7 +445,7 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             int rc = debug_session_step(s);
             if (rc == WIRE_OK && debug_session_read_regs(s, s_regs) == WIRE_OK) {
                 s_regs_ok = 1;
-                s_pc = s_regs[15];
+                s_pc = s_regs[debug_session_pc_reg(s)];
             }
             redraw(s, dbi);
 
@@ -455,7 +454,7 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
             int rc = debug_session_continue(s);
             if (rc == WIRE_OK && debug_session_read_regs(s, s_regs) == WIRE_OK) {
                 s_regs_ok = 1;
-                s_pc = s_regs[15];
+                s_pc = s_regs[debug_session_pc_reg(s)];
             }
             redraw(s, dbi);
 

--- a/src/mkdbg.h
+++ b/src/mkdbg.h
@@ -209,6 +209,7 @@ typedef struct {
   const char *port;
   int         baud;
   const char *elf_path;
+  const char *arch;  /* --arch name, e.g. "cortex-m"; NULL defaults to "cortex-m" */
 } DebugOptions;
 
 typedef struct {

--- a/src/parse.c
+++ b/src/parse.c
@@ -495,6 +495,9 @@ int parse_debug_args(int argc, char **argv, DebugOptions *opts)
     } else if (strcmp(argv[i], "--elf") == 0) {
       if (i + 1 >= argc) die("missing value for --elf");
       opts->elf_path = argv[++i];
+    } else if (strcmp(argv[i], "--arch") == 0) {
+      if (i + 1 >= argc) die("missing value for --arch");
+      opts->arch = argv[++i];
     } else if (argv[i][0] == '-') {
       die("unknown debug argument: %s", argv[i]);
     } else {

--- a/tests/arch_test.c
+++ b/tests/arch_test.c
@@ -60,6 +60,26 @@ int main(void)
               "zero payload: timeout flag set (halt_signal=0)");
     }
 
+    /* cortex-m live_debug descriptor */
+    CHECK(cm != NULL && cm->live_debug != NULL,
+          "cortex-m has live_debug descriptor");
+    CHECK(cm != NULL && cm->live_debug != NULL && cm->live_debug->nregs == 17,
+          "cortex-m live_debug->nregs == 17");
+    CHECK(cm != NULL && cm->live_debug != NULL && cm->live_debug->pc_reg_idx == 15,
+          "cortex-m live_debug->pc_reg_idx == 15");
+
+    /* riscv32 arch registration and live_debug */
+    const MkdbgArch *rv = mkdbg_arch_find("riscv32");
+    CHECK(rv != NULL, "mkdbg_arch_find(\"riscv32\") != NULL");
+    CHECK(rv != NULL && strcmp(rv->name, "riscv32") == 0,
+          "riscv32 arch->name == \"riscv32\"");
+    CHECK(rv != NULL && rv->live_debug != NULL,
+          "riscv32 has live_debug descriptor");
+    CHECK(rv != NULL && rv->live_debug != NULL && rv->live_debug->nregs == 33,
+          "riscv32 live_debug->nregs == 33");
+    CHECK(rv != NULL && rv->live_debug != NULL && rv->live_debug->pc_reg_idx == 32,
+          "riscv32 live_debug->pc_reg_idx == 32");
+
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return (tests_passed == tests_run) ? 0 : 1;
 }


### PR DESCRIPTION
- Add ArchLiveDebug struct to arch.h; extend MkdbgArch with live_debug field
- Add cortex_m_live descriptor (17 regs, pc=15, sp=13) in cortex_m.c
- Add arch/riscv32.c: 33-reg RISC-V 32-bit plugin (pc=32, sp=2)
- Register riscv32 in arch_registry.c; add to arch_test and CMakeLists.txt
- debug_session: store MkdbgArch*, expose nregs/reg_name/pc_reg accessors
- debug_session_open() takes const MkdbgArch* third param
- debug_cli: --arch flag lookup via mkdbg_arch_find; use arch accessors in do_regs() and print_halt() replacing hardcoded Cortex-M indices
- debug_tui: replace s_regs[DEBUG_SESSION_NREGS] with MAX_REGS; replace s_regs[15] (hardcoded PC) with debug_session_pc_reg(s); replace rname() with debug_session_reg_name(s, i) in draw_reg_bp()
- arch_test: add 8 new checks for live_debug descriptors on both archs