### PR TITLE
fix: Linux CI build errors (strdup, termbox2 unused-result)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ add_executable(mkdbg-native
   $<TARGET_OBJECTS:seam_lib>
   $<TARGET_OBJECTS:wire_crash_lib>
 )
+# termbox2 is a vendored single-header lib; suppress its unused-result warning
+set_source_files_properties(src/termbox2_impl.c PROPERTIES
+  COMPILE_OPTIONS "-Wno-unused-result"
+)
 target_compile_options(mkdbg-native PRIVATE -Wall -Wextra -Werror -O2)
 target_include_directories(mkdbg-native PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/src

--- a/src/dwarf.c
+++ b/src/dwarf.c
@@ -7,6 +7,11 @@
  * SPDX-License-Identifier: MIT
  */
 
+/* strdup is POSIX, not C11 — request it before any system header */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "dwarf.h"
 
 #include <fcntl.h>

--- a/src/mkdbg.h
+++ b/src/mkdbg.h
@@ -1,11 +1,17 @@
 #ifndef MKDBG_H
 #define MKDBG_H
 
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
 #ifdef __APPLE__
+#ifndef _DARWIN_C_SOURCE
 #define _DARWIN_C_SOURCE
+#endif
 #else
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
+#endif
 #endif
 
 #include <ctype.h>


### PR DESCRIPTION
## Summary

- Add `#define _POSIX_C_SOURCE 200809L` before first include in `dwarf.c` — `strdup()` was implicitly declared under strict C11 on glibc, causing `-Werror` to fail
- Suppress `-Wno-unused-result` for `termbox2_impl.c` in CMake — vendored single-header library intentionally ignores `write`/`read` return values

## Test plan

- [ ] CI: linux-x86_64 and linux-arm64 release builds complete without errors
- [ ] macOS builds unaffected