### PR TITLE
fix(install): add bash re-exec guard so `curl | sh` works — BASH_SOUR…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ No J-Link. No ST-Link. No OpenOCD. No GDB required for a crash report.
 **1. Install the host tool**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/JialongWang1201/mkdbg/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/JialongWang1201/mkdbg/main/scripts/install.sh | bash
 ```
 
 Or build from source (requires `cmake` and a C compiler):

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -27,7 +27,7 @@ This installs the native C frontend as `mkdbg`.
 One-line remote install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/JialongWang1201/mkdbg/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/JialongWang1201/mkdbg/main/scripts/install.sh | bash
 ```
 
 The remote installer currently builds the native frontend from source and

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,13 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+# When invoked as `curl URL | sh`, the shebang is ignored and sh runs this.
+# Ensure we continue under bash (required for pipefail, [[...]], BASH_SOURCE, arrays).
+# These lines must be POSIX sh — no bash-isms before the exec.
+if [ -z "${BASH_VERSION:-}" ]; then
+  if ! command -v bash >/dev/null 2>&1; then
+    echo "error: bash is required to install mkdbg" >&2; exit 1
+  fi
+  exec bash -s "$@"
+fi
 set -euo pipefail
 
 INSTALL_DIR="${MKDBG_INSTALL_DIR:-$HOME/.local/bin}"


### PR DESCRIPTION
When run as `curl URL | sh`, the shebang is ignored and POSIX sh executes the script. BASH_SOURCE[0] is bash-only, and `set -u` then aborts immediately with "BASH_SOURCE[0]: unbound variable".

Fix: add a pure-sh guard at the very top that re-execs with bash when BASH_VERSION is not set. The guard is POSIX sh compatible (no [[]], no arrays, no BASH_SOURCE) so sh can execute it before handing off to bash.

Also update install one-liners in README and COMMANDS.md to use `bash` instead of `sh` as belt-and-suspenders documentation.