### PR TITLE
feat: colored UI, first-run wizard, zero-dependency probe

### DIFF
--- a/examples/stm32f446/scripts/mkdbg_native_host_tests.sh
+++ b/examples/stm32f446/scripts/mkdbg_native_host_tests.sh
@@ -390,11 +390,9 @@ for item in checks:
         raise SystemExit(f"missing expected watch render text: {item}")
 PY
 
+# attach --port dry-run: wire dump path
 PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" attach --target microkernel \
-  --break main \
-  --command continue \
-  --command bt \
-  --batch \
+  --port /dev/ttyACM0 \
   --dry-run > "${ATTACH_DRY_OUT}"
 python3 - "${ATTACH_DRY_OUT}" <<'PY'
 import sys
@@ -402,20 +400,20 @@ from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
 checks = [
-    "[mkdbg] cwd=",
-    "[mkdbg] openocd=openocd -f ",
-    "[mkdbg] gdb=arm-none-eabi-gdb ",
-    "MicroKernel_MPU.elf",
-    "-batch",
-    "-ex 'target extended-remote localhost:3333'",
-    "-ex 'break main'",
-    "-ex continue",
-    "-ex bt",
+    "[dry-run] wire-host --dump --port /dev/ttyACM0",
 ]
 for item in checks:
     if item not in text:
         raise SystemExit(f"missing expected attach dry-run output: {item}")
 PY
+
+# attach with scripted flags but no port/attach_cmd → must fail
+if PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" attach --target microkernel \
+    --break main --command continue --batch --dry-run \
+    > /dev/null 2> "${ATTACH_ERR_OUT}"; then
+  echo "mkdbg_native_host_tests: expected attach without port to fail" >&2
+  exit 1
+fi
 
 PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" target add tahoe \
   --path . \
@@ -434,63 +432,67 @@ if needle not in text:
     raise SystemExit(f"missing expected attach error text: {needle}")
 PY
 
-PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe halt --target microkernel --dry-run > "${PROBE_HALT_OUT}"
+# probe halt dry-run: wire RSP path
+PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe halt --port /dev/ttyACM0 --dry-run > "${PROBE_HALT_OUT}"
 python3 - "${PROBE_HALT_OUT}" <<'PY'
 import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
 checks = [
-    "[mkdbg] cwd=",
-    "[mkdbg] cmd=openocd -f ",
-    "reset halt; shutdown",
+    "[dry-run]",
+    "port=/dev/ttyACM0",
+    "rsp=?",
 ]
 for item in checks:
     if item not in text:
         raise SystemExit(f"missing expected probe halt output: {item}")
 PY
 
-PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe flash --target microkernel --dry-run > "${PROBE_FLASH_OUT}"
+# probe flash is removed — must fail
+if PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe flash --target microkernel --dry-run \
+    > "${PROBE_FLASH_OUT}" 2>&1; then
+  echo "mkdbg_native_host_tests: expected probe flash to fail (removed command)" >&2
+  exit 1
+fi
 python3 - "${PROBE_FLASH_OUT}" <<'PY'
 import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
-checks = [
-    "[mkdbg] cmd=openocd -f ",
-    "program /",
-    "MicroKernel_MPU.elf",
-    "verify reset exit",
-]
-for item in checks:
-    if item not in text:
-        raise SystemExit(f"missing expected probe flash output: {item}")
+needle = "probe flash removed"
+if needle not in text:
+    raise SystemExit(f"missing expected probe flash error text: {needle}")
 PY
 
-PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe read32 --target microkernel --dry-run 0xE000ED28 > "${PROBE_READ32_OUT}"
+# probe read32 dry-run: wire RSP path
+PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe read32 --port /dev/ttyACM0 --dry-run 0xE000ED28 > "${PROBE_READ32_OUT}"
 python3 - "${PROBE_READ32_OUT}" <<'PY'
 import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
 checks = [
-    "mdw 0xe000ed28",
-    "shutdown",
+    "[dry-run]",
+    "port=/dev/ttyACM0",
+    "rsp=me000ed28,4",
 ]
 for item in checks:
     if item not in text:
         raise SystemExit(f"missing expected probe read32 output: {item}")
 PY
 
-PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe write32 --target microkernel --dry-run 0xE000ED24 0x700 > "${PROBE_WRITE32_OUT}"
+# probe write32 dry-run: wire RSP path
+PATH="${BIN_DIR}:${PATH}" "${NATIVE_BIN}" probe write32 --port /dev/ttyACM0 --dry-run 0xE000ED24 0x700 > "${PROBE_WRITE32_OUT}"
 python3 - "${PROBE_WRITE32_OUT}" <<'PY'
 import sys
 from pathlib import Path
 
 text = Path(sys.argv[1]).read_text(encoding="utf-8")
 checks = [
-    "mww 0xe000ed24 0x00000700",
-    "shutdown",
+    "[dry-run]",
+    "port=/dev/ttyACM0",
+    "rsp=Me000ed24,4:",
 ]
 for item in checks:
     if item not in text:

--- a/src/main.c
+++ b/src/main.c
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
   g_color = isatty(STDOUT_FILENO);
 
   if (argc == 2 && strcmp(argv[1], "--version") == 0) {
-    printf("mkdbg %s\n", MKDBG_NATIVE_VERSION);
+    printf("mkdbg-native %s\n", MKDBG_NATIVE_VERSION);
     return 0;
   }
   if (argc < 2 ||

--- a/src/probe.c
+++ b/src/probe.c
@@ -65,6 +65,10 @@ static void u32_to_le_hex(uint32_t v, char out[9])
 /* probe halt: query halt reason via RSP '?' */
 int cmd_probe_halt(const ProbeOptions *opts)
 {
+  if (opts->dry_run) {
+    printf("[dry-run] port=%s  rsp=?\n", opts->port ? opts->port : "<unset>");
+    return 0;
+  }
   int fd = probe_open(opts);
   if (fd < 0) return 1;
 
@@ -92,6 +96,10 @@ int cmd_probe_halt(const ProbeOptions *opts)
 /* probe resume: send RSP 'c' and get the S00 acknowledge */
 int cmd_probe_resume(const ProbeOptions *opts)
 {
+  if (opts->dry_run) {
+    printf("[dry-run] port=%s  rsp=c\n", opts->port ? opts->port : "<unset>");
+    return 0;
+  }
   int fd = probe_open(opts);
   if (fd < 0) return 1;
 
@@ -110,6 +118,10 @@ int cmd_probe_resume(const ProbeOptions *opts)
 /* probe reset: send RSP 'R00' — send-only, MCU resets immediately */
 int cmd_probe_reset(const ProbeOptions *opts)
 {
+  if (opts->dry_run) {
+    printf("[dry-run] port=%s  rsp=R00\n", opts->port ? opts->port : "<unset>");
+    return 0;
+  }
   int fd = probe_open(opts);
   if (fd < 0) return 1;
 
@@ -138,6 +150,12 @@ int cmd_probe_read32(const ProbeOptions *opts)
   if (errno != 0 || *end != '\0') {
     fprintf(stderr, "mkdbg: invalid address: %s\n", opts->address);
     return 1;
+  }
+
+  if (opts->dry_run) {
+    printf("[dry-run] port=%s  rsp=m%x,4\n",
+           opts->port ? opts->port : "<unset>", addr);
+    return 0;
   }
 
   int fd = probe_open(opts);
@@ -183,6 +201,14 @@ int cmd_probe_write32(const ProbeOptions *opts)
   if (errno != 0 || *end != '\0') {
     fprintf(stderr, "mkdbg: invalid value: %s\n", opts->value);
     return 1;
+  }
+
+  if (opts->dry_run) {
+    char hexdata[9];
+    u32_to_le_hex(val, hexdata);
+    printf("[dry-run] port=%s  rsp=M%x,4:%s\n",
+           opts->port ? opts->port : "<unset>", addr, hexdata);
+    return 0;
   }
 
   int fd = probe_open(opts);


### PR DESCRIPTION
## Summary

- Colored help output with ASCII logo and bold section headers (ANSI, TTY-gated)
- First-run wizard fires when no args, both TTYs, and no `.mkdbg.toml` found
- `mkdbg probe` rewritten to use wire UART RSP directly — no openocd/gdb dependency
- `mkdbg attach --port` now uses wire dump path; openocd+gdb path removed
- `mkdbg doctor` openocd/gdb checks only run when `openocd_cfg` is configured
- Fix: `--version` now prints `mkdbg-native X.Y.Z` to match CI expectations

## Test plan

- [ ] `tests/smoke.sh` — mkdbg-native --version, arch_test, dwarf_test
- [ ] `examples/stm32f446/scripts/mkdbg_native_host_tests.sh` — full host integration