### PR TITLE
feat(fpbv2): Cortex-M7/M33 breakpoint support via FPBv2 runtime detection

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -176,3 +176,14 @@ Baud rate mismatch.  Pass `--baud <rate>` to mkdbg.
 
 `parse_registers` got a short RSP response.  Verify `wire_uart_recv` blocks
 until all bytes arrive (not just one read-and-return).
+
+**Live debug breakpoints not firing on Cortex-M7 or Cortex-M33**
+
+These cores use FPBv2 (Flash Patch and Breakpoint revision 2).  The wire
+agent auto-detects the revision at runtime by reading `FPB_CTRL.REV`
+(bits [31:28]).  FPBv2 requires a KEY bit alongside ENABLE in the same
+write to `FP_CTRL` — a read-modify-write is silently ignored.
+
+`wire_enable_debug_monitor()` handles this automatically.  If breakpoints
+still do not fire, check that `DEMCR.MON_EN` is set and that DebugMonitor
+is not masked by `BASEPRI` or `PRIMASK` on your target.


### PR DESCRIPTION
## Summary

- `wire_rsp.c`: detects FPB revision at runtime via `FPB_CTRL.REV` [31:28]
- FPBv2 (M7/M33/M35P): uses `FPB_COMP_WORD_V2(addr) = addr | 1u` — direct address, no REPLACE bits
- FPBv1 (M3/M4): unchanged `FPB_COMP_WORD_V1(addr)` with REPLACE=11
- `wire_enable_debug_monitor()`: writes KEY=1 alongside ENABLE=1 for FPBv2 (read-modify-write silently fails on FPBv2)
- `wire_exception.c`: updated comment to reflect both revisions
- `docs/PORTING.md`: new troubleshooting entry for FPBv2 breakpoints

No host-side changes needed — host sends Z1/z1 RSP packets identically for both revisions.

## Test plan

- [ ] CI smoke passes (firmware-side change; host tests unaffected)
- [ ] Manual: breakpoint on Cortex-M33 target fires DebugMonitor correctly