### PR TITLE
feat(soft-halt): add host-side interrupt command and firmware break-i…

### DIFF
--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -112,6 +112,45 @@ in under a second.
 
 ---
 
+## Optional — break-in (soft-halt a running MCU)
+
+By default `wire_uart_try_read()` is a weak stub that always returns 0.
+Override it in your BSP to allow the host to halt a running MCU without a
+hardware debug probe:
+
+```c
+/* bsp/uart.c — non-blocking UART read for break-in detection */
+#include "wire.h"
+
+int wire_uart_try_read(uint8_t *byte)
+{
+    if (__HAL_UART_GET_FLAG(&huart2, UART_FLAG_RXNE)) {
+        *byte = (uint8_t)huart2.Instance->RDR;
+        return 1;
+    }
+    return 0;
+}
+```
+
+Then call `wire_poll_break_in()` from your main loop or RTOS idle hook:
+
+```c
+for (;;) {
+    wire_poll_break_in();   /* detects Ctrl-C (0x03) from mkdbg */
+    do_work();
+}
+```
+
+When the host sends Ctrl-C (via `mkdbg debug` → `interrupt` command or `i`
+key in TUI mode), `wire_poll_break_in()` pends DebugMonitor and the CPU
+halts at the next instruction.
+
+Requires `WIRE_LIVE_DEBUG=1` and `wire_enable_debug_monitor()` to have been
+called (done automatically by `wire_init()` when `WIRE_LIVE_DEBUG` is
+defined).
+
+---
+
 ## Optional — seam event ring
 
 seam lets you record what happened *before* the crash.  Feed it events during
@@ -145,6 +184,7 @@ mkdbg seam analyze capture.cfl
 [ ] link deps/wire/src/wire_agent.c into firmware
 [ ] flash and test: trigger a HardFault, run mkdbg attach
 [ ] optional: link deps/seam/src/seam_agent.c, call seam_emit()
+[ ] optional: override wire_uart_try_read(), call wire_poll_break_in() in main loop
 ```
 
 ---

--- a/src/debug_cli.c
+++ b/src/debug_cli.c
@@ -353,6 +353,7 @@ static void print_help(void)
         "  display 0x<addr>         add memory address to display list\n"
         "  undisplay <id>           remove from display list\n"
         "  continue  (c)            resume execution; wait for next halt\n"
+        "  interrupt (int)          send Ctrl-C break-in; halt running MCU\n"
         "  step      (s)            single-step one instruction\n"
         "  regs                     print all CPU registers\n"
         "  mem 0x<addr> [len]       hexdump memory (default 16 bytes, max 256)\n"
@@ -430,6 +431,12 @@ int cmd_debug(const DebugOptions *opts)
             int rc = debug_session_continue(s);
             if (rc == WIRE_OK) print_halt(s);
             else printf("error: continue failed (rc=%d)\n", rc);
+        } else if (strcmp(cmd, "interrupt") == 0 || strcmp(cmd, "int") == 0) {
+            printf("Sending break-in...\n");
+            int rc = debug_session_interrupt(s);
+            if (rc == WIRE_OK) print_halt(s);
+            else printf("error: interrupt timed out (MCU did not halt; "
+                        "check wire_poll_break_in() is called in firmware)\n");
         } else if (strcmp(cmd, "step") == 0 || strcmp(cmd, "s") == 0) {
             int rc = debug_session_step(s);
             if (rc == WIRE_OK) print_halt(s);

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -89,6 +89,21 @@ int debug_session_detach(DebugSession *s)
     return rsp_send_packet(s->fd, "c");
 }
 
+int debug_session_interrupt(DebugSession *s)
+{
+    /* Send raw Ctrl-C (0x03) — not an RSP packet, just one byte.
+     * The firmware's wire_poll_break_in() detects it and pends DebugMonitor. */
+    uint8_t ctrlc = 0x03u;
+    ssize_t n = write(s->fd, &ctrlc, 1);
+    if (n != 1) return WIRE_ERR_IO;
+
+    char stop[16];
+    int rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    if (rc == WIRE_OK)
+        s->last_signal = parse_stop_signal(stop);
+    return rc;
+}
+
 int debug_session_step(DebugSession *s)
 {
     /* 's' has NO immediate reply per RSP spec — send directly, not via

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -46,6 +46,12 @@ int debug_session_continue(DebugSession *s);
  * Used on quit to leave the MCU running. */
 int debug_session_detach(DebugSession *s);
 
+/* Send a Ctrl-C (0x03) break-in byte to the MCU and wait for the halt
+ * stop reply.  The firmware must be polling wire_poll_break_in() from its
+ * main loop for this to work.  Returns WIRE_OK on halt,
+ * WIRE_ERR_TIMEOUT if the MCU does not halt within 60 s. */
+int debug_session_interrupt(DebugSession *s);
+
 /* Execute one instruction; block until DebugMonitor fires.
  * Returns WIRE_OK on halt, WIRE_ERR_TIMEOUT if step takes > 60 s. */
 int debug_session_step(DebugSession *s);

--- a/src/debug_tui.c
+++ b/src/debug_tui.c
@@ -306,7 +306,7 @@ static void draw_bottom(int y_border, int y_hint, int w)
     bchar(w - 1, y_border, "\xe2\x94\x98");            /* ┘ */
 
     tb_print(0, y_hint, TB_YELLOW, TB_DEFAULT,
-             "[s]tep [c]ontinue [b]reak [d]el [w]atch [m]em [t]cli [q]uit");
+             "[s]tep [c]ontinue [i]nterrupt [b]reak [d]el [w]atch [m]em [t]cli [q]uit");
 }
 
 /* ── Status bar (replaces hint bar during blocking ops) ──────────────────── */
@@ -490,6 +490,19 @@ int debug_tui_run(DebugSession *s, DwarfDBI *dbi)
                 s_regs_ok = 1;
                 s_pc = s_regs[debug_session_pc_reg(s)];
                 tui_update_task(s, dbi);
+            }
+            redraw(s, dbi);
+
+        } else if (ev.ch == 'i') {
+            draw_status(y_hint, w, "Sending break-in...  (waiting for halt)");
+            int rc = debug_session_interrupt(s);
+            if (rc == WIRE_OK && debug_session_read_regs(s, s_regs) == WIRE_OK) {
+                s_regs_ok = 1;
+                s_pc = s_regs[debug_session_pc_reg(s)];
+                tui_update_task(s, dbi);
+            } else if (rc != WIRE_OK) {
+                draw_status(y_hint, w,
+                    "Break-in timed out (check wire_poll_break_in in firmware)");
             }
             redraw(s, dbi);
 


### PR DESCRIPTION
…n support

Host-side changes for soft-halt: send Ctrl-C (0x03) to a running MCU and wait for the DebugMonitor halt, without needing a hardware debug probe.

- debug_session_interrupt(): writes raw 0x03 to UART, waits for stop reply
- debug_cli.c: 'interrupt' / 'int' command with clear error for timeout
- debug_tui.c: 'i' key triggers break-in, shown in hint bar
- docs/PORTING.md: document wire_uart_try_read override and break-in usage
- Bump wire submodule to df861f3 (weak try_read + poll_break_in)