### PR TITLE
feat(thumb-dis): add P3 FPU instruction support (VLDR/VSTR, VADD/VSUB…

### DIFF
--- a/src/thumb_dis.c
+++ b/src/thumb_dis.c
@@ -3,6 +3,7 @@
  * Coverage:
  *   P1: MOV/MOVW/MOVT, LDR/STR (T1-T4), PUSH/POP, BL/BLX, B (all conds)
  *   P2: ADD/SUB/MUL, CMP/TST/AND/ORR/EOR/BIC/MVN, LSL/LSR/ASR, IT block
+ *   P3: VLDR/VSTR, VADD/VSUB/VMUL (F32), VMOV (imm/reg/core↔FPU), VCVT
  *   Unknown encodings → "<unknown 0xXXXX>" (never crashes)
  *
  * SPDX-License-Identifier: MIT
@@ -640,6 +641,148 @@ static int decode_32(uint32_t pc, uint16_t hw1, uint16_t hw2,
         case 4: snprintf(out, out_sz, "teq%s.w %s, %s", cs, s_reg[rn], s_reg[rm]); goto done32;
         case 8: snprintf(out, out_sz, "cmn%s.w %s, %s", cs, s_reg[rn], s_reg[rm]); goto done32;
         case 13: snprintf(out, out_sz, "cmp%s.w %s, %s", cs, s_reg[rn], s_reg[rm]); goto done32;
+        }
+    }
+
+    /* ── VFP/FPU (Cortex-M4 FPv4-SP-D16) ────────────────────────────────── */
+    /*
+     * All VFP SP instructions have hw1[15:8] in [0xEC..0xEF] and
+     * hw2[11:8]=0b1010 (cp10, single-precision).
+     *
+     * Register encoding (5-bit SP regs s0..s31):
+     *   Sd = Vd*2+D  where Vd=hw2[15:12], D=hw1[6]
+     *   Sn = Vn*2+N  where Vn=hw1[3:0],   N=hw2[7]
+     *   Sm = Vm*2+M  where Vm=hw2[3:0],    M=hw2[5]
+     *
+     * Instruction groups distinguished by hw1[15:8]:
+     *   0xED: VLDR / VSTR
+     *   0xEE, hw2&0x0F70==0x0A10: VMOV (core↔VFP) or VMRS
+     *   0xEE, otherwise:          VFP data-processing
+     *
+     * Within VFP data-processing, op_nD removes the D bit from hw1[7:4]:
+     *   op_nD = ((hw1>>5)&4) | ((hw1>>4)&3)
+     *     2 → VMUL
+     *     3 → VADD (hw2[6]=0) / VSUB (hw2[6]=1)
+     *     4 → VDIV
+     *     7 → miscellaneous unary/convert (distinguished by hw1[3:0] and hw2[7])
+     *
+     * Verified against arm-none-eabi-as output (ARMv7E-M, FPv4-SP-D16).
+     */
+    if ((hw1 & 0xff00u) >= 0xec00u && (hw2 & 0x0f00u) == 0x0a00u) {
+        uint8_t  D  = (hw1 >> 6) & 1u;
+        uint8_t  Vn = hw1 & 0xfu;
+        uint8_t  Vd = (hw2 >> 12) & 0xfu;
+        uint8_t  N  = (hw2 >> 7) & 1u;   /* also used as op2 (signed) in VCVT */
+        uint8_t  Vm = hw2 & 0xfu;
+        uint8_t  M  = (hw2 >> 5) & 1u;
+        unsigned sd = (unsigned)Vd * 2u + D;
+        unsigned sn = (unsigned)Vn * 2u + N;
+        unsigned sm = (unsigned)Vm * 2u + M;
+
+        /* ── VLDR / VSTR (hw1[15:8]=0xED) ──────────────────────────────── */
+        if ((hw1 & 0xff00u) == 0xed00u) {
+            uint8_t  load = (hw1 >> 4) & 1u;   /* L=1 → VLDR, L=0 → VSTR */
+            uint8_t  U    = (hw1 >> 7) & 1u;   /* U=1 → add offset */
+            uint8_t  Rn   = hw1 & 0xfu;
+            uint32_t off  = (uint32_t)(hw2 & 0xffu) * 4u;
+            const char *base = (Rn == 15) ? "pc" : s_reg[Rn];
+            if (off == 0)
+                snprintf(out, out_sz, "%s%s s%u, [%s]",
+                         load ? "vldr" : "vstr", cs, sd, base);
+            else if (U)
+                snprintf(out, out_sz, "%s%s s%u, [%s, #%u]",
+                         load ? "vldr" : "vstr", cs, sd, base, off);
+            else
+                snprintf(out, out_sz, "%s%s s%u, [%s, #-%u]",
+                         load ? "vldr" : "vstr", cs, sd, base, off);
+            goto done32;
+        }
+
+        if ((hw1 & 0xff00u) == 0xee00u) {
+            /* ── VMOV core↔VFP / VMRS (fixed hw2 pattern) ─────────────── */
+            /* hw2[6:4]=001 (with N free at hw2[7]):  hw2 & 0x0F70 == 0x0A10 */
+            if ((hw2 & 0x0f70u) == 0x0a10u) {
+                uint8_t op47 = (hw1 >> 4) & 0xfu;   /* hw1[7:4] */
+                uint8_t Rt   = (hw2 >> 12) & 0xfu;
+                if (op47 == 0xfu) {
+                    /* VMRS: hw1[7:4]=1111 (FPSCR system register) */
+                    if (Rt == 15)
+                        snprintf(out, out_sz, "vmrs%s APSR_nzcv, fpscr", cs);
+                    else
+                        snprintf(out, out_sz, "vmrs%s %s, fpscr", cs, s_reg[Rt]);
+                } else {
+                    /* VMOV between ARM core reg and SP VFP reg.
+                     * L=hw1[4]: 0=ARM→VFP, 1=VFP→ARM.
+                     * Sn = Vn*2+N where Vn=hw1[3:0], N=hw2[7]. */
+                    if ((hw1 >> 4) & 1u)
+                        snprintf(out, out_sz, "vmov%s %s, s%u", cs, s_reg[Rt], sn);
+                    else
+                        snprintf(out, out_sz, "vmov%s s%u, %s", cs, sn, s_reg[Rt]);
+                }
+                goto done32;
+            }
+
+            /* ── VFP data-processing ─────────────────────────────────────── */
+            /* op_nD: hw1[7] in bit2, hw1[5:4] in bits[1:0] — removes D(hw1[6]) */
+            uint8_t op_nD = (uint8_t)(((hw1 >> 5) & 4u) | ((hw1 >> 4) & 3u));
+            switch (op_nD) {
+            case 0x2:   /* VMUL */
+                snprintf(out, out_sz, "vmul%s.f32 s%u, s%u, s%u", cs, sd, sn, sm);
+                goto done32;
+            case 0x3:   /* VADD / VSUB distinguished by hw2[6] */
+                if (hw2 & 0x40u)
+                    snprintf(out, out_sz, "vsub%s.f32 s%u, s%u, s%u", cs, sd, sn, sm);
+                else
+                    snprintf(out, out_sz, "vadd%s.f32 s%u, s%u, s%u", cs, sd, sn, sm);
+                goto done32;
+            case 0x4:   /* VDIV */
+                snprintf(out, out_sz, "vdiv%s.f32 s%u, s%u, s%u", cs, sd, sn, sm);
+                goto done32;
+            case 0x7: { /* miscellaneous: VMOV, VABS, VNEG, VSQRT, VCVT, VCMP */
+                uint8_t vn_lo = hw1 & 0xfu;   /* hw1[3:0] selects sub-operation */
+                if (vn_lo & 0x8u) {
+                    /* VCVT: hw1[3]=1. hw1[2]=to_int, hw1[0]=signed(to_int case)
+                     * hw2[7](=N)=signed for to_float case. */
+                    if (hw1 & 0x4u) {
+                        /* to integer (float→int) */
+                        const char *sfx = (hw1 & 0x1u) ? "s" : "u";
+                        snprintf(out, out_sz, "vcvt%s.%s32.f32 s%u, s%u",
+                                 cs, sfx, sd, sm);
+                    } else {
+                        /* to float (int→float): signed/unsigned from hw2[7] */
+                        const char *sfx = N ? "s" : "u";
+                        snprintf(out, out_sz, "vcvt%s.f32.%s32 s%u, s%u",
+                                 cs, sfx, sd, sm);
+                    }
+                    goto done32;
+                }
+                if (vn_lo == 0x4u) {
+                    /* VCMP */
+                    snprintf(out, out_sz, "vcmp%s.f32 s%u, s%u", cs, sd, sm);
+                    goto done32;
+                }
+                /* VMOV.F32 / VABS / VNEG / VSQRT: distinguished by vn_lo and hw2[7] */
+                if (vn_lo == 0x0u) {
+                    /* hw2[7]=0 → VMOV.F32;  hw2[7]=1 → VABS */
+                    if (N)
+                        snprintf(out, out_sz, "vabs%s.f32 s%u, s%u", cs, sd, sm);
+                    else
+                        snprintf(out, out_sz, "vmov%s.f32 s%u, s%u", cs, sd, sm);
+                    goto done32;
+                }
+                if (vn_lo == 0x1u) {
+                    /* hw2[7]=0 → VNEG;  hw2[7]=1 → VSQRT */
+                    if (N)
+                        snprintf(out, out_sz, "vsqrt%s.f32 s%u, s%u", cs, sd, sm);
+                    else
+                        snprintf(out, out_sz, "vneg%s.f32 s%u, s%u", cs, sd, sm);
+                    goto done32;
+                }
+                break;
+            }
+            default:
+                break;
+            }
         }
     }
 

--- a/src/thumb_dis.h
+++ b/src/thumb_dis.h
@@ -8,8 +8,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* Minimum output buffer size guaranteed to hold any P1/P2 mnemonic. */
-#define THUMB_DIS_OUT_MAX 64
+/* Minimum output buffer size guaranteed to hold any P1/P2/P3 mnemonic. */
+#define THUMB_DIS_OUT_MAX 96
 
 /* Disassemble one Thumb/Thumb-2 instruction.
  *

--- a/tests/test_thumb_dis.c
+++ b/tests/test_thumb_dis.c
@@ -10,6 +10,8 @@
  *       STM/LDM, IT block instruction
  *   32-bit: BL, MOVW, MOVT, ADDW, SUBW, LDR.W, STR.W, ADD.W, B.W, BEQ.W
  *   IT state machine: multi-step ITTEE block (4 instructions, 2T+2E)
+ *   P3 FPU: VLDR/VSTR, VADD/VSUB/VMUL/VDIV, VMOV.F32, VABS/VNEG/VSQRT,
+ *           VCVT (f32↔s32/u32), VCMP, VMOV(core↔VFP), VMRS
  *   Edge cases: buf_len < 2, buf_len == 2 for 32-bit prefix, unknown encoding,
  *               itstate=NULL degraded mode
  *
@@ -584,6 +586,91 @@ static void test_pc_relative(void)
           "adr r0, 0x00001008", 2); }
 }
 
+/* ── P3 FPU instruction tests ─────────────────────────────────────────────── */
+/* All byte sequences verified with arm-none-eabi-as (FPv4-SP-D16, Thumb). */
+
+static void test_fpu(void)
+{
+    printf("\n--- P3 FPU instructions ---\n");
+
+    /* ── VLDR / VSTR ─────────────────────────────────────────────────────── */
+    { const uint8_t b[] = {0x90,0xED,0x00,0x0A}; /* ed90 0a00 */
+      chk("vldr s0, [r0]", 0x1000, b, 4, NULL, "vldr s0, [r0]", 4); }
+
+    { const uint8_t b[] = {0x90,0xED,0x02,0x0A}; /* ed90 0a02 */
+      chk("vldr s0, [r0, #8]", 0x1000, b, 4, NULL, "vldr s0, [r0, #8]", 4); }
+
+    { const uint8_t b[] = {0x10,0xED,0x02,0x0A}; /* ed10 0a02 */
+      chk("vldr s0, [r0, #-8]", 0x1000, b, 4, NULL, "vldr s0, [r0, #-8]", 4); }
+
+    { const uint8_t b[] = {0x80,0xED,0x00,0x0A}; /* ed80 0a00 */
+      chk("vstr s0, [r0]", 0x1000, b, 4, NULL, "vstr s0, [r0]", 4); }
+
+    { const uint8_t b[] = {0x81,0xED,0x01,0x1A}; /* ed81 1a01 */
+      chk("vstr s2, [r1, #4]", 0x1000, b, 4, NULL, "vstr s2, [r1, #4]", 4); }
+
+    /* ── VADD / VSUB / VMUL / VDIV ──────────────────────────────────────── */
+    { const uint8_t b[] = {0x31,0xEE,0x02,0x0A}; /* ee31 0a02 */
+      chk("vadd.f32 s0, s2, s4", 0x1000, b, 4, NULL, "vadd.f32 s0, s2, s4", 4); }
+
+    { const uint8_t b[] = {0x31,0xEE,0x42,0x0A}; /* ee31 0a42 */
+      chk("vsub.f32 s0, s2, s4", 0x1000, b, 4, NULL, "vsub.f32 s0, s2, s4", 4); }
+
+    { const uint8_t b[] = {0x21,0xEE,0x02,0x0A}; /* ee21 0a02 */
+      chk("vmul.f32 s0, s2, s4", 0x1000, b, 4, NULL, "vmul.f32 s0, s2, s4", 4); }
+
+    { const uint8_t b[] = {0x81,0xEE,0x02,0x0A}; /* ee81 0a02 */
+      chk("vdiv.f32 s0, s2, s4", 0x1000, b, 4, NULL, "vdiv.f32 s0, s2, s4", 4); }
+
+    /* ── VMOV.F32 (register copy) ───────────────────────────────────────── */
+    { const uint8_t b[] = {0xB0,0xEE,0x41,0x0A}; /* eeb0 0a41 */
+      chk("vmov.f32 s0, s2", 0x1000, b, 4, NULL, "vmov.f32 s0, s2", 4); }
+
+    { const uint8_t b[] = {0xF0,0xEE,0x41,0x0A}; /* eef0 0a41 */
+      chk("vmov.f32 s1, s2", 0x1000, b, 4, NULL, "vmov.f32 s1, s2", 4); }
+
+    /* ── VABS / VNEG / VSQRT ────────────────────────────────────────────── */
+    { const uint8_t b[] = {0xB0,0xEE,0xC1,0x0A}; /* eeb0 0ac1 */
+      chk("vabs.f32 s0, s2", 0x1000, b, 4, NULL, "vabs.f32 s0, s2", 4); }
+
+    { const uint8_t b[] = {0xB1,0xEE,0x41,0x0A}; /* eeb1 0a41 */
+      chk("vneg.f32 s0, s2", 0x1000, b, 4, NULL, "vneg.f32 s0, s2", 4); }
+
+    { const uint8_t b[] = {0xB1,0xEE,0xC1,0x0A}; /* eeb1 0ac1 */
+      chk("vsqrt.f32 s0, s2", 0x1000, b, 4, NULL, "vsqrt.f32 s0, s2", 4); }
+
+    /* ── VCVT ────────────────────────────────────────────────────────────── */
+    { const uint8_t b[] = {0xB8,0xEE,0xC1,0x0A}; /* eeb8 0ac1 */
+      chk("vcvt.f32.s32 s0, s2", 0x1000, b, 4, NULL, "vcvt.f32.s32 s0, s2", 4); }
+
+    { const uint8_t b[] = {0xB8,0xEE,0x40,0x0A}; /* eeb8 0a40 */
+      chk("vcvt.f32.u32 s0, s0", 0x1000, b, 4, NULL, "vcvt.f32.u32 s0, s0", 4); }
+
+    { const uint8_t b[] = {0xBD,0xEE,0xC1,0x0A}; /* eebd 0ac1 */
+      chk("vcvt.s32.f32 s0, s2", 0x1000, b, 4, NULL, "vcvt.s32.f32 s0, s2", 4); }
+
+    { const uint8_t b[] = {0xBC,0xEE,0xC1,0x0A}; /* eebc 0ac1 */
+      chk("vcvt.u32.f32 s0, s2", 0x1000, b, 4, NULL, "vcvt.u32.f32 s0, s2", 4); }
+
+    /* ── VCMP ────────────────────────────────────────────────────────────── */
+    { const uint8_t b[] = {0xB4,0xEE,0x41,0x0A}; /* eeb4 0a41 */
+      chk("vcmp.f32 s0, s2", 0x1000, b, 4, NULL, "vcmp.f32 s0, s2", 4); }
+
+    /* ── VMOV core↔VFP ──────────────────────────────────────────────────── */
+    { const uint8_t b[] = {0x00,0xEE,0x10,0x0A}; /* ee00 0a10 */
+      chk("vmov s0, r0", 0x1000, b, 4, NULL, "vmov s0, r0", 4); }
+
+    { const uint8_t b[] = {0x11,0xEE,0x10,0x1A}; /* ee11 1a10 */
+      chk("vmov r1, s2", 0x1000, b, 4, NULL, "vmov r1, s2", 4); }
+
+    /* ── VMRS ────────────────────────────────────────────────────────────── */
+    { const uint8_t b[] = {0xF1,0xEE,0x10,0xFA}; /* eef1 fa10 */
+      chk("vmrs APSR_nzcv, fpscr", 0x1000, b, 4, NULL, "vmrs APSR_nzcv, fpscr", 4); }
+
+    { const uint8_t b[] = {0xF1,0xEE,0x10,0x0A}; /* eef1 0a10 */
+      chk("vmrs r0, fpscr", 0x1000, b, 4, NULL, "vmrs r0, fpscr", 4); }
+}
+
 /* ── main ─────────────────────────────────────────────────────────────────── */
 
 int main(void)
@@ -593,6 +680,7 @@ int main(void)
     test_it();
     test_edge();
     test_pc_relative();
+    test_fpu();
 
     printf("\n%d/%d passed\n", s_pass, s_run);
     return (s_pass == s_run) ? 0 : 1;


### PR DESCRIPTION
…/VMUL/VDIV, VCVT, VMOV, VMRS)

Extend thumb_dis_one() with Cortex-M4 FPv4-SP-D16 single-precision VFP instruction decoding.  Eliminates <unknown> output in hard-float firmware.

Instructions covered:
  VLDR / VSTR (immediate offset, pos/neg)
  VADD / VSUB / VMUL / VDIV (f32)
  VMOV.F32 (register copy), VABS, VNEG, VSQRT (f32)
  VCVT (f32↔s32, f32↔u32), VCMP (f32)
  VMOV (ARM core reg ↔ SP VFP reg), VMRS (FPSCR → core / APSR_nzcv)

All encodings verified against arm-none-eabi-as output. THUMB_DIS_OUT_MAX raised 64→96 to accommodate longer FPU mnemonics. 23 golden tests added (131/131 pass).