### PR TITLE
feat(transport): introduce WireTransport abstraction (PR-1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ add_executable(mkdbg-native
   src/seam.c
   src/dashboard.c
   src/wire.c
+  src/uart_transport.c
+  src/rsp_transport.c
   src/debug_session.c
   src/debug_cli.c
   src/debug_tui.c

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -1,10 +1,13 @@
-/* debug_session.c — Live debug session over UART (RSP client)
+/* debug_session.c — Live debug session over WireTransport (RSP client)
  *
  * SPDX-License-Identifier: MIT
  */
 
 #include "debug_session.h"
 #include "arch.h"
+#include "transport.h"
+#include "rsp_transport.h"
+#include "uart_transport.h"
 #include "wire_host.h"
 
 #include <stdio.h>
@@ -15,7 +18,7 @@
 /* ── Internal state ──────────────────────────────────────────────────────── */
 
 struct DebugSession {
-    int              fd;           /* serial port file descriptor */
+    WireTransport   *transport;    /* byte-stream backend (UART or probe) */
     int              last_signal;  /* GDB signal from most recent stop reply */
     const MkdbgArch *arch;         /* active architecture (live_debug guaranteed non-NULL) */
 };
@@ -42,27 +45,38 @@ static int parse_stop_signal(const char *reply)
 
 /* ── Lifecycle ───────────────────────────────────────────────────────────── */
 
+/*
+ * Open a session from a pre-constructed transport.  Takes ownership of t;
+ * transport_destroy() is called on debug_session_close().
+ * Used by debug_session_open() (UART) and in PR-3 by probe_transport.
+ */
+DebugSession *debug_session_open_transport(WireTransport *t,
+                                            const MkdbgArch *arch)
+{
+    if (!t || !arch) return NULL;
+    DebugSession *s = malloc(sizeof(DebugSession));
+    if (!s) return NULL;
+    s->transport   = t;
+    s->last_signal = 0;
+    s->arch        = arch;
+    return s;
+}
+
 DebugSession *debug_session_open(const char *port, int baud,
                                   const MkdbgArch *arch)
 {
-    int fd = wire_serial_open(port, baud);
-    if (fd < 0) return NULL;
+    WireTransport *t = uart_transport_open(port, baud);
+    if (!t) return NULL;
 
-    DebugSession *s = malloc(sizeof(DebugSession));
-    if (!s) {
-        close(fd);
-        return NULL;
-    }
-    s->fd          = fd;
-    s->last_signal = 0;
-    s->arch        = arch;
+    DebugSession *s = debug_session_open_transport(t, arch);
+    if (!s) { transport_destroy(t); return NULL; }
     return s;
 }
 
 void debug_session_close(DebugSession *s)
 {
     if (!s) return;
-    close(s->fd);
+    transport_destroy(s->transport);
     free(s);
 }
 
@@ -73,11 +87,11 @@ int debug_session_continue(DebugSession *s)
     char resp[16];
 
     /* 'c' gets S00 immediately (MCU resuming); then wait for halt stop reply. */
-    int rc = rsp_transaction(s->fd, "c", resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, "c", resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
 
     char stop[16];
-    rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    rc = rsp_wait_for_stop_t(s->transport, stop, sizeof(stop));
     if (rc == WIRE_OK)
         s->last_signal = parse_stop_signal(stop);
     return rc;
@@ -86,7 +100,7 @@ int debug_session_continue(DebugSession *s)
 int debug_session_detach(DebugSession *s)
 {
     /* Send 'c' but do NOT wait — leave the MCU running and return. */
-    return rsp_send_packet(s->fd, "c");
+    return rsp_send_packet_t(s->transport, "c");
 }
 
 int debug_session_interrupt(DebugSession *s)
@@ -94,11 +108,11 @@ int debug_session_interrupt(DebugSession *s)
     /* Send raw Ctrl-C (0x03) — not an RSP packet, just one byte.
      * The firmware's wire_poll_break_in() detects it and pends DebugMonitor. */
     uint8_t ctrlc = 0x03u;
-    ssize_t n = write(s->fd, &ctrlc, 1);
+    int n = s->transport->write(s->transport->ctx, &ctrlc, 1);
     if (n != 1) return WIRE_ERR_IO;
 
     char stop[16];
-    int rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    int rc = rsp_wait_for_stop_t(s->transport, stop, sizeof(stop));
     if (rc == WIRE_OK)
         s->last_signal = parse_stop_signal(stop);
     return rc;
@@ -107,13 +121,13 @@ int debug_session_interrupt(DebugSession *s)
 int debug_session_step(DebugSession *s)
 {
     /* 's' has NO immediate reply per RSP spec — send directly, not via
-     * rsp_transaction().  The stop-reply S05 arrives when DebugMonitor
+     * rsp_transaction_t().  The stop-reply S05 arrives when DebugMonitor
      * fires after the CPU executes one instruction. */
-    int rc = rsp_send_packet(s->fd, "s");
+    int rc = rsp_send_packet_t(s->transport, "s");
     if (rc != WIRE_OK) return rc;
 
     char stop[16];
-    rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    rc = rsp_wait_for_stop_t(s->transport, stop, sizeof(stop));
     if (rc == WIRE_OK)
         s->last_signal = parse_stop_signal(stop);
     return rc;
@@ -127,7 +141,7 @@ int debug_session_set_hw_breakpoint(DebugSession *s, uint32_t addr)
     snprintf(cmd, sizeof(cmd), "Z1,%x,4", addr);
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -138,7 +152,7 @@ int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr)
     snprintf(cmd, sizeof(cmd), "z1,%x,4", addr);
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -152,7 +166,7 @@ int debug_session_set_watchpoint(DebugSession *s, uint32_t addr,
     snprintf(cmd, sizeof(cmd), "Z%d,%x,%x", (int)type, addr, len ? len : 1);
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -165,7 +179,7 @@ int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr)
     int types[3] = { WATCHPOINT_WRITE, WATCHPOINT_READ, WATCHPOINT_ACCESS };
     for (int i = 0; i < 3; i++) {
         snprintf(cmd, sizeof(cmd), "z%d,%x,1", types[i], addr);
-        int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+        int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
         if (rc == WIRE_OK && strcmp(resp, "OK") == 0) return WIRE_OK;
     }
     return WIRE_ERR_IO;
@@ -178,7 +192,7 @@ int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_MAX_REG
     int nregs = s->arch->live_debug->nregs;
     /* RSP 'g': nregs registers × 8 hex chars each, little-endian. */
     char resp[DEBUG_SESSION_MAX_REGS * 8 + 4];
-    int rc = rsp_transaction(s->fd, "g", resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, "g", resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     if (resp[0] == 'E') return WIRE_ERR_IO;
 
@@ -205,7 +219,7 @@ int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *
     char resp[4096];
     if (len * 2 + 4 > sizeof(resp)) return WIRE_ERR_OVERFLOW;
 
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     if (resp[0] == 'E') return WIRE_ERR_IO;
 
@@ -233,7 +247,7 @@ int debug_session_write_mem(DebugSession *s, uint32_t addr, size_t len,
     cmd[hdr + len * 2] = '\0';
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -241,9 +255,9 @@ int debug_session_write_mem(DebugSession *s, uint32_t addr, size_t len,
 int debug_session_reset(DebugSession *s)
 {
     /* RSP 'R' packet: software system reset.
-     * The MCU resets immediately and sends NO reply — use rsp_send_packet,
-     * not rsp_transaction, to avoid blocking on a reply that never arrives. */
-    return rsp_send_packet(s->fd, "R00");
+     * The MCU resets immediately and sends NO reply — use rsp_send_packet_t,
+     * not rsp_transaction_t, to avoid blocking on a reply that never arrives. */
+    return rsp_send_packet_t(s->transport, "R00");
 }
 
 /* ── Arch metadata ───────────────────────────────────────────────────────── */

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -15,8 +15,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* Forward-declare MkdbgArch to avoid circular includes. */
-typedef struct MkdbgArch MkdbgArch;
+/* Forward-declare MkdbgArch and WireTransport to avoid circular includes. */
+typedef struct MkdbgArch    MkdbgArch;
+typedef struct WireTransport WireTransport;
 
 /* Opaque session handle. */
 typedef struct DebugSession DebugSession;
@@ -32,6 +33,12 @@ typedef struct DebugSession DebugSession;
  * Returns NULL on error (error printed to stderr). */
 DebugSession *debug_session_open(const char *port, int baud,
                                   const MkdbgArch *arch);
+
+/* Open a session from a pre-constructed WireTransport.
+ * Takes ownership of t; transport_destroy() is called on debug_session_close().
+ * Used by probe_transport.c (PR-3) to attach via hardware probe. */
+DebugSession *debug_session_open_transport(WireTransport *t,
+                                            const MkdbgArch *arch);
 
 /* Close UART and free the session. */
 void debug_session_close(DebugSession *s);

--- a/src/rsp_transport.c
+++ b/src/rsp_transport.c
@@ -1,0 +1,172 @@
+/* rsp_transport.c — GDB RSP packet framing over WireTransport.
+ *
+ * Re-implements the RSP client (deps/wire/host/wire_rsp_client.c) using
+ * WireTransport callbacks.  The fd-based RSP client is still used by the crash
+ * dump path (wire_dump_crash_to_buf); this file is for the live debug session.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "rsp_transport.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#define RSP_BUF_MAX        4096
+#define RSP_MAX_RETRIES       3
+#define RSP_TIMEOUT_MS     2000
+#define RSP_WAIT_STOP_RETRIES 30   /* 30 × 2 s = 60 s */
+
+/* ── helpers ─────────────────────────────────────────────────────────────── */
+
+static uint8_t rsp_checksum(const char *data, size_t len)
+{
+    uint8_t sum = 0;
+    for (size_t i = 0; i < len; i++)
+        sum = (uint8_t)(sum + (uint8_t)data[i]);
+    return sum;
+}
+
+static int hex_nibble(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/*
+ * Read exactly one byte with timeout_ms via transport.
+ * Returns 1 on success, WIRE_ERR_TIMEOUT on timeout, WIRE_ERR_IO on error.
+ */
+static int read_byte_t(WireTransport *t, uint8_t *out, int timeout_ms)
+{
+    int r = t->read(t->ctx, out, 1, timeout_ms);
+    if (r == 1) return 1;
+    if (r == TRANSPORT_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+    return WIRE_ERR_IO;
+}
+
+/*
+ * Write one byte via transport.  Returns WIRE_OK or WIRE_ERR_IO.
+ */
+static int write_byte_t(WireTransport *t, uint8_t b)
+{
+    int r = t->write(t->ctx, &b, 1);
+    return (r == 1) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+/* ── send ────────────────────────────────────────────────────────────────── */
+
+int rsp_send_packet_t(WireTransport *t, const char *data)
+{
+    size_t  dlen = strlen(data);
+    uint8_t sum  = rsp_checksum(data, dlen);
+    char    buf[RSP_BUF_MAX + 8];
+    int     n    = snprintf(buf, sizeof(buf), "$%s#%02x", data, sum);
+    if (n < 0 || (size_t)n >= sizeof(buf)) return WIRE_ERR_OVERFLOW;
+
+    int r = t->write(t->ctx, (const uint8_t *)buf, (int)n);
+    return (r == n) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+/* ── receive ─────────────────────────────────────────────────────────────── */
+
+static int rsp_recv_packet_t(WireTransport *t, char *out_buf, size_t out_size)
+{
+    uint8_t c;
+
+    /* drain until '$' */
+    for (;;) {
+        int r = read_byte_t(t, &c, RSP_TIMEOUT_MS);
+        if (r == WIRE_ERR_IO)      return WIRE_ERR_IO;
+        if (r == WIRE_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+        if (c == '$') break;
+    }
+
+    /* accumulate data until '#' */
+    size_t  dlen        = 0;
+    uint8_t running_sum = 0;
+    for (;;) {
+        int r = read_byte_t(t, &c, RSP_TIMEOUT_MS);
+        if (r == WIRE_ERR_IO)      return WIRE_ERR_IO;
+        if (r == WIRE_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+        if (c == '#') break;
+        if (dlen + 1 >= out_size) {
+            write_byte_t(t, '-');
+            return WIRE_ERR_OVERFLOW;
+        }
+        out_buf[dlen++] = (char)c;
+        running_sum     = (uint8_t)(running_sum + c);
+    }
+    out_buf[dlen] = '\0';
+
+    /* read 2-hex checksum */
+    uint8_t hi, lo;
+    if (read_byte_t(t, &hi, RSP_TIMEOUT_MS) != 1) return WIRE_ERR_IO;
+    if (read_byte_t(t, &lo, RSP_TIMEOUT_MS) != 1) return WIRE_ERR_IO;
+
+    int h = hex_nibble((char)hi);
+    int l = hex_nibble((char)lo);
+    if (h < 0 || l < 0) {
+        write_byte_t(t, '-');
+        return WIRE_ERR_CHECKSUM;
+    }
+
+    uint8_t expected = (uint8_t)((h << 4) | l);
+    if (running_sum != expected) {
+        write_byte_t(t, '-');
+        return WIRE_ERR_CHECKSUM;
+    }
+
+    write_byte_t(t, '+');
+    return WIRE_OK;
+}
+
+/* ── public API ──────────────────────────────────────────────────────────── */
+
+int rsp_wait_for_stop_t(WireTransport *t, char *out_buf, size_t out_size)
+{
+    for (int i = 0; i < RSP_WAIT_STOP_RETRIES; i++) {
+        int rc = rsp_recv_packet_t(t, out_buf, out_size);
+        if (rc == WIRE_ERR_TIMEOUT) continue;
+        if (rc != WIRE_OK)          return rc;
+        if (out_buf[0] == 'S' || out_buf[0] == 'T')
+            return WIRE_OK;
+        /* stale ACK or unexpected packet — keep waiting */
+    }
+    return WIRE_ERR_TIMEOUT;
+}
+
+int rsp_transaction_t(WireTransport *t, const char *cmd,
+                      char *resp_buf, size_t resp_size)
+{
+    for (int cmd_try = 0; cmd_try < RSP_MAX_RETRIES; cmd_try++) {
+        int rc = rsp_send_packet_t(t, cmd);
+        if (rc != WIRE_OK) return rc;
+
+        /* Wait for server ACK/NAK of our command */
+        uint8_t ack;
+        int r = read_byte_t(t, &ack, RSP_TIMEOUT_MS);
+        if (r == WIRE_ERR_IO)      return WIRE_ERR_IO;
+        if (r == WIRE_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+        if (ack == '-') {
+            fprintf(stderr, "mkdbg: RSP NAK on '%s', retrying (%d/%d)\n",
+                    cmd, cmd_try + 1, RSP_MAX_RETRIES);
+            continue;
+        }
+        if (ack != '+') continue;  /* unexpected byte, retransmit */
+
+        /* Server ACK'd; receive response with checksum retry */
+        for (int resp_try = 0; resp_try < RSP_MAX_RETRIES; resp_try++) {
+            rc = rsp_recv_packet_t(t, resp_buf, resp_size);
+            if (rc == WIRE_OK) return WIRE_OK;
+            if (rc != WIRE_ERR_CHECKSUM) return rc;
+            fprintf(stderr, "mkdbg: RSP response checksum error, retry %d/%d\n",
+                    resp_try + 1, RSP_MAX_RETRIES);
+        }
+        return WIRE_ERR_CHECKSUM;
+    }
+    return WIRE_ERR_CHECKSUM;
+}

--- a/src/rsp_transport.h
+++ b/src/rsp_transport.h
@@ -1,0 +1,38 @@
+/* rsp_transport.h — GDB RSP packet framing over WireTransport.
+ *
+ * Drop-in replacement for deps/wire/host/wire_rsp_client.c that uses
+ * WireTransport callbacks instead of a raw POSIX fd, enabling the same
+ * RSP logic to run over UART or a hardware probe bridge.
+ *
+ * Return values mirror wire_host.h WIRE_* codes so callers are unchanged.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef RSP_TRANSPORT_H
+#define RSP_TRANSPORT_H
+
+#include "transport.h"
+#include "wire_host.h"   /* WIRE_OK, WIRE_ERR_* */
+
+#include <stddef.h>
+
+/*
+ * Send one RSP packet ($data#checksum) without waiting for a reply.
+ * Used for commands that have no immediate response (e.g. 's' single-step).
+ */
+int rsp_send_packet_t(WireTransport *t, const char *data);
+
+/*
+ * Block until the target sends a spontaneous stop reply (S or T packet).
+ * Retries for up to ~60 s.  Returns WIRE_OK with the reply in out_buf.
+ */
+int rsp_wait_for_stop_t(WireTransport *t, char *out_buf, size_t out_size);
+
+/*
+ * Send cmd and receive the server response, with NAK/retransmit (up to 3×).
+ * Returns WIRE_OK on success.
+ */
+int rsp_transaction_t(WireTransport *t, const char *cmd,
+                      char *resp_buf, size_t resp_size);
+
+#endif /* RSP_TRANSPORT_H */

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,0 +1,44 @@
+/* transport.h — Abstract byte-stream transport for debug_session.
+ *
+ * Decouples debug_session.c from the concrete I/O mechanism so that the same
+ * RSP client code works over a UART fd (uart_transport.c) or a hardware probe
+ * via probe-bridge (probe_transport.c, PR-3).
+ *
+ * Error codes returned by read/write callbacks:
+ *   TRANSPORT_ERR_IO      — OS-level I/O error
+ *   TRANSPORT_ERR_TIMEOUT — read timed out (caller should retry or abort)
+ *   TRANSPORT_ERR_CLOSED  — peer closed the connection
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef TRANSPORT_H
+#define TRANSPORT_H
+
+#include <stdint.h>
+
+#define TRANSPORT_OK           0
+#define TRANSPORT_ERR_IO      (-1)
+#define TRANSPORT_ERR_TIMEOUT (-2)
+#define TRANSPORT_ERR_CLOSED  (-3)
+
+/*
+ * WireTransport — pluggable byte-stream backend.
+ *
+ * read():  read up to len bytes into buf; timeout_ms is a per-call wall-clock
+ *          limit.  Returns bytes transferred (>= 1) or a negative error code.
+ * write(): write exactly len bytes from buf.  Returns bytes written (== len on
+ *          success) or a negative error code.
+ * close(): release all resources; transport must not be used after this call.
+ * ctx:     opaque pointer forwarded to every callback.
+ */
+typedef struct WireTransport {
+    int  (*read) (void *ctx, uint8_t *buf, int len, int timeout_ms);
+    int  (*write)(void *ctx, const uint8_t *buf, int len);
+    void (*close)(void *ctx);
+    void *ctx;
+} WireTransport;
+
+/* Free the WireTransport struct itself after calling t->close(t->ctx). */
+void transport_destroy(WireTransport *t);
+
+#endif /* TRANSPORT_H */

--- a/src/uart_transport.c
+++ b/src/uart_transport.c
@@ -1,0 +1,93 @@
+/* uart_transport.c — WireTransport adapter for POSIX serial / PTY fds.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "uart_transport.h"
+#include "wire_host.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/select.h>
+#include <unistd.h>
+
+/* ── internal context ────────────────────────────────────────────────────── */
+
+typedef struct {
+    int fd;
+} UartCtx;
+
+/* ── callbacks ───────────────────────────────────────────────────────────── */
+
+static int uart_read(void *ctx, uint8_t *buf, int len, int timeout_ms)
+{
+    UartCtx *u = ctx;
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(u->fd, &rfds);
+    struct timeval tv;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+retry:;
+    int r = select(u->fd + 1, &rfds, NULL, NULL, &tv);
+    if (r < 0) {
+        if (errno == EINTR) {
+            FD_ZERO(&rfds);
+            FD_SET(u->fd, &rfds);
+            goto retry;
+        }
+        return TRANSPORT_ERR_IO;
+    }
+    if (r == 0) return TRANSPORT_ERR_TIMEOUT;
+
+    ssize_t n = read(u->fd, buf, (size_t)len);
+    if (n < 0)
+        return (errno == EAGAIN || errno == EINTR)
+               ? TRANSPORT_ERR_TIMEOUT : TRANSPORT_ERR_IO;
+    if (n == 0) return TRANSPORT_ERR_CLOSED;
+    return (int)n;
+}
+
+static int uart_write(void *ctx, const uint8_t *buf, int len)
+{
+    UartCtx *u = ctx;
+    ssize_t n = write(u->fd, buf, (size_t)len);
+    if (n < 0) return TRANSPORT_ERR_IO;
+    if (n == 0) return TRANSPORT_ERR_CLOSED;
+    return (int)n;
+}
+
+static void uart_close(void *ctx)
+{
+    UartCtx *u = ctx;
+    close(u->fd);
+    free(u);
+}
+
+/* ── public ──────────────────────────────────────────────────────────────── */
+
+void transport_destroy(WireTransport *t)
+{
+    if (!t) return;
+    if (t->close) t->close(t->ctx);
+    free(t);
+}
+
+WireTransport *uart_transport_open(const char *port, int baud)
+{
+    int fd = wire_serial_open(port, baud);
+    if (fd < 0) return NULL;
+
+    UartCtx *ctx = malloc(sizeof(UartCtx));
+    if (!ctx) { close(fd); return NULL; }
+    ctx->fd = fd;
+
+    WireTransport *t = malloc(sizeof(WireTransport));
+    if (!t) { close(fd); free(ctx); return NULL; }
+    t->read  = uart_read;
+    t->write = uart_write;
+    t->close = uart_close;
+    t->ctx   = ctx;
+    return t;
+}

--- a/src/uart_transport.h
+++ b/src/uart_transport.h
@@ -1,0 +1,19 @@
+/* uart_transport.h — POSIX fd wrapped as WireTransport.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef UART_TRANSPORT_H
+#define UART_TRANSPORT_H
+
+#include "transport.h"
+
+/*
+ * Open a UART or PTY and return a heap-allocated WireTransport.
+ * port  — device path, e.g. "/dev/ttyUSB0"
+ * baud  — baud rate; pass 0 for PTY / QEMU (no baud negotiation)
+ * Returns NULL on error (message printed to stderr).
+ * Caller destroys with transport_destroy().
+ */
+WireTransport *uart_transport_open(const char *port, int baud);
+
+#endif /* UART_TRANSPORT_H */


### PR DESCRIPTION
Add a pluggable byte-stream transport layer so debug_session.c is no longer coupled to a raw POSIX fd.  No behaviour change for existing UART sessions; probe-bridge (PR-2/3) will plug in a second transport.

New files:
- src/transport.h        — WireTransport struct + error codes
- src/uart_transport.h/c — POSIX fd wrapped as WireTransport
- src/rsp_transport.h/c  — RSP packet framing over WireTransport

debug_session.c now holds WireTransport* instead of int fd and calls rsp_*_t() instead of rsp_*().  debug_session_open_transport() exposed for PR-3 (probe_transport).

All existing tests pass.