### PR TITLE
feat(probe-transport): wire probe-bridge into mkdbg attach (PR-3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,53 @@ set_target_properties(mkdbg-native PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
 )
 
+# ── probe-bridge: Rust staticlib (optional, requires cargo) ──────────────────
+# Pass -DMKDBG_SKIP_PROBE=ON to disable even when cargo is available.
+option(MKDBG_SKIP_PROBE "Disable probe-bridge integration" OFF)
+find_program(CARGO cargo PATHS "$ENV{HOME}/.cargo/bin" /usr/local/bin /opt/homebrew/bin)
+if(CARGO AND NOT MKDBG_SKIP_PROBE)
+  set(PROBE_BRIDGE_DIR "${CMAKE_SOURCE_DIR}/probe-bridge")
+  set(PROBE_BRIDGE_LIB
+      "${CMAKE_BINARY_DIR}/probe-bridge/release/libprobe_bridge.a")
+
+  add_custom_command(
+    OUTPUT  "${PROBE_BRIDGE_LIB}"
+    COMMAND "${CARGO}" build --release
+            --manifest-path "${PROBE_BRIDGE_DIR}/Cargo.toml"
+            --target-dir    "${CMAKE_BINARY_DIR}/probe-bridge"
+    DEPENDS "${PROBE_BRIDGE_DIR}/Cargo.toml"
+            "${PROBE_BRIDGE_DIR}/src/lib.rs"
+            "${PROBE_BRIDGE_DIR}/src/rsp.rs"
+    COMMENT "Building probe-bridge (Rust)"
+    VERBATIM
+  )
+  add_custom_target(probe_bridge_target DEPENDS "${PROBE_BRIDGE_LIB}")
+
+  target_sources(mkdbg-native PRIVATE src/probe_transport.c)
+  target_include_directories(mkdbg-native PRIVATE
+    "${PROBE_BRIDGE_DIR}/include"
+  )
+  target_compile_definitions(mkdbg-native PRIVATE MKDBG_PROBE_SUPPORT=1)
+  target_link_libraries(mkdbg-native PRIVATE "${PROBE_BRIDGE_LIB}")
+  add_dependencies(mkdbg-native probe_bridge_target)
+
+  if(APPLE)
+    target_link_libraries(mkdbg-native PRIVATE
+      "-framework IOKit"
+      "-framework CoreFoundation"
+      "-framework Security"
+    )
+  endif()
+
+  message(STATUS "probe-bridge: enabled (${CARGO})")
+else()
+  if(MKDBG_SKIP_PROBE)
+    message(STATUS "probe-bridge: disabled (MKDBG_SKIP_PROBE=ON)")
+  else()
+    message(STATUS "probe-bridge: disabled (cargo not found)")
+  endif()
+endif()
+
 # ── seam-analyze: standalone causal-chain analysis tool ──────────────────────
 add_executable(seam-analyze
   src/seam_main.c

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -1,4 +1,11 @@
 #include "mkdbg.h"
+#include "arch.h"
+#include "debug_session.h"
+#include "debug_tui.h"
+#ifdef MKDBG_PROBE_SUPPORT
+#include "probe_bridge.h"
+#include "probe_transport.h"
+#endif
 
 int cmd_capture_bundle(const CaptureBundleOptions *opts)
 {
@@ -216,8 +223,67 @@ int cmd_attach(const AttachOptions *opts)
     return run_process(shell_argv, repo_root, opts->dry_run);
   }
 
+#ifdef MKDBG_PROBE_SUPPORT
+  /* Probe path: auto-detect or use explicit --probe N */
+  {
+    ProbeInfo probes[16];
+    int n = probe_list(probes, 16);
+    if (n < 0) {
+      fprintf(stderr, "mkdbg: probe enumeration failed\n");
+      return 1;
+    }
+    if (n == 0) {
+      fprintf(stderr,
+              "mkdbg: no debug probe detected\n"
+              "       insert a CMSIS-DAP / ST-Link / J-Link probe, "
+              "or pass --port for UART\n");
+      return 1;
+    }
+    int idx = opts->probe_idx;
+    if (idx < 0) {
+      if (n > 1) {
+        int i;
+        fprintf(stderr, "mkdbg: %d probes found — select one with --probe N:\n", n);
+        for (i = 0; i < n; i++) {
+          fprintf(stderr, "  [%d] %s  serial: %s\n",
+                  i,
+                  probes[i].identifier[0] ? (char *)probes[i].identifier : "unknown",
+                  probes[i].serial[0]     ? (char *)probes[i].serial     : "(none)");
+        }
+        return 1;
+      }
+      idx = 0;
+    } else if (idx >= n) {
+      fprintf(stderr, "mkdbg: --probe %d out of range (%d probe(s) found)\n", idx, n);
+      return 1;
+    }
+    if (opts->dry_run) {
+      printf("[dry-run] probe_open(%d, %s) → open debug TUI\n",
+             idx, opts->chip ? opts->chip : "auto");
+      return 0;
+    }
+    {
+      const MkdbgArch *arch = mkdbg_arch_find("cortex-m");
+      WireTransport   *t;
+      DebugSession    *s;
+      if (!arch || !arch->live_debug) {
+        fprintf(stderr, "mkdbg: cortex-m arch does not support live debug\n");
+        return 1;
+      }
+      t = probe_transport_open(idx, opts->chip);
+      if (!t) return 1;
+      s = debug_session_open_transport(t, arch);
+      if (!s) { transport_destroy(t); return 1; }
+      printf("mkdbg probe debug  probe=%d  chip=%s\n",
+             idx, opts->chip ? opts->chip : "auto");
+      return debug_tui_run(s, NULL);
+    }
+  }
+#else
   fprintf(stderr,
           "mkdbg: attach requires --port to read a crash report over UART\n"
+          "       (probe support not compiled in; rebuild with cargo in PATH)\n"
           "       mkdbg attach --port /dev/ttyUSB0\n");
   return 1;
+#endif
 }

--- a/src/mkdbg.h
+++ b/src/mkdbg.h
@@ -151,6 +151,9 @@ typedef struct {
   const char *target;
   const char *port;
   const char *baud;
+  /* Probe flags: probe_idx=-1 means auto-detect; chip=NULL means auto IDCODE */
+  int         probe_idx;
+  const char *chip;
   const char *breakpoints[MAX_ATTACH_BREAKPOINTS];
   size_t breakpoint_count;
   const char *gdb_commands[MAX_ATTACH_COMMANDS];

--- a/src/parse.c
+++ b/src/parse.c
@@ -233,6 +233,7 @@ int parse_attach_args(int argc, char **argv, AttachOptions *opts)
 {
   int i;
   memset(opts, 0, sizeof(*opts));
+  opts->probe_idx = -1; /* auto-detect */
   opts->server_wait_s = 1.2;
 
   for (i = 0; i < argc; ++i) {
@@ -267,6 +268,16 @@ int parse_attach_args(int argc, char **argv, AttachOptions *opts)
         die("too many --command arguments");
       }
       opts->gdb_commands[opts->gdb_command_count++] = argv[++i];
+    } else if (strcmp(argv[i], "--probe") == 0) {
+      char *end = NULL;
+      long v;
+      if (i + 1 >= argc) die("missing value for --probe");
+      v = strtol(argv[++i], &end, 10);
+      if (!end || *end != '\0' || v < 0) die("--probe requires a non-negative integer");
+      opts->probe_idx = (int)v;
+    } else if (strcmp(argv[i], "--chip") == 0) {
+      if (i + 1 >= argc) die("missing value for --chip");
+      opts->chip = argv[++i];
     } else if (strcmp(argv[i], "--batch") == 0) {
       opts->batch = 1;
     } else if (strcmp(argv[i], "--dry-run") == 0) {

--- a/src/probe_transport.c
+++ b/src/probe_transport.c
@@ -1,0 +1,58 @@
+/* probe_transport.c — WireTransport adapter backed by probe-bridge.
+ *
+ * Wraps the five probe_bridge C FFI functions (probe_open / probe_read /
+ * probe_write / probe_close) as a WireTransport so that debug_session.c's
+ * RSP client works identically over UART or a hardware debug probe.
+ *
+ * Compiled only when MKDBG_PROBE_SUPPORT is defined by CMakeLists.txt.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "probe_transport.h"
+#include "probe_bridge.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* ── WireTransport callbacks ─────────────────────────────────────────────── */
+
+static int pt_read(void *ctx, uint8_t *buf, int len, int timeout_ms)
+{
+    return probe_read((ProbeHandle *)ctx, buf, len, timeout_ms);
+}
+
+static int pt_write(void *ctx, const uint8_t *buf, int len)
+{
+    return probe_write((ProbeHandle *)ctx, buf, len);
+}
+
+static void pt_close(void *ctx)
+{
+    probe_close((ProbeHandle *)ctx);
+}
+
+/* ── public API ──────────────────────────────────────────────────────────── */
+
+WireTransport *probe_transport_open(int probe_idx, const char *chip)
+{
+    ProbeHandle *h = probe_open(probe_idx, chip);
+    if (!h) {
+        fprintf(stderr, "mkdbg: probe_open(%d, %s) failed\n",
+                probe_idx, chip ? chip : "auto");
+        return NULL;
+    }
+
+    WireTransport *t = malloc(sizeof(WireTransport));
+    if (!t) {
+        probe_close(h);
+        return NULL;
+    }
+
+    t->read  = pt_read;
+    t->write = pt_write;
+    t->close = pt_close;
+    t->ctx   = h;
+    return t;
+}

--- a/src/probe_transport.h
+++ b/src/probe_transport.h
@@ -1,0 +1,24 @@
+/* probe_transport.h — WireTransport adapter backed by probe-bridge.
+ *
+ * Only compiled when MKDBG_PROBE_SUPPORT is defined (cargo found at
+ * configure time).  All callers must guard with #ifdef MKDBG_PROBE_SUPPORT.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef PROBE_TRANSPORT_H
+#define PROBE_TRANSPORT_H
+
+#include "transport.h"
+
+/*
+ * probe_transport_open — open probe[probe_idx] and return a WireTransport.
+ *
+ * probe_idx  index from probe_list(); pass 0 when only one probe is present.
+ * chip       chip name (e.g. "STM32F446RETx"), or NULL for auto-detect.
+ *
+ * Returns a heap-allocated WireTransport on success, NULL on failure.
+ * Caller destroys with transport_destroy().
+ */
+WireTransport *probe_transport_open(int probe_idx, const char *chip);
+
+#endif /* PROBE_TRANSPORT_H */


### PR DESCRIPTION
Integrates the probe-bridge staticlib into the C build and adds hardware probe auto-detect to `mkdbg attach`.

New files:
  src/probe_transport.c   WireTransport adapter wrapping probe_{open,read,
                          write,close} — thin shim, no policy
  src/probe_transport.h   public header

Changed files:
  CMakeLists.txt          find_program(CARGO), custom_command for cargo build
                          --release, link libprobe_bridge.a + macOS frameworks,
                          MKDBG_PROBE_SUPPORT define, MKDBG_SKIP_PROBE option
  src/mkdbg.h             AttachOptions gains probe_idx (-1=auto) and chip
  src/parse.c             parse_attach_args handles --probe N and --chip NAME
  src/launcher.c          cmd_attach probe path (guarded by MKDBG_PROBE_SUPPORT):
                            0 probes → clear error + hint
                            1 probe  → probe_transport_open → debug_session_open_transport → TUI
                            >1 probe → list all, ask for --probe N
                          no MKDBG_PROBE_SUPPORT → old error message preserved

Build without cargo: MKDBG_SKIP_PROBE=ON or cargo absent → UART-only binary, no source changes needed.