### PR TITLE
feat(probe-ci): Rust toolchain in CI/release + doctor probe diagnostics (PR-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --no-self-update
+
       - name: Build mkdbg-native and wire-host (CMake, with libgit2)
         run: |
           set -euxo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,19 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      # Rust is needed for probe-bridge on native builds.
+      # Cross-compile legs skip probe support (MKDBG_SKIP_PROBE=ON) to avoid
+      # requiring a cross-Rust toolchain in CI.
+      - name: Install Rust toolchain (native builds)
+        if: "!matrix.cross"
+        run: rustup toolchain install stable --no-self-update
+
+      # macOS x86_64 is cross-compiled from the arm64 runner; add the x86_64
+      # Rust target so cargo produces a compatible static lib.
+      - name: Add x86_64-apple-darwin Rust target (darwin-x86_64 leg)
+        if: matrix.osx_arch == 'x86_64'
+        run: rustup target add x86_64-apple-darwin
+
       - name: Configure (native)
         if: "!matrix.cross"
         run: |
@@ -69,7 +82,8 @@ jobs:
             -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
             -DCMAKE_SYSTEM_NAME=Linux \
             -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
-            -DMKDBG_SKIP_LG2=ON
+            -DMKDBG_SKIP_LG2=ON \
+            -DMKDBG_SKIP_PROBE=ON
 
       - name: Build
         run: cmake --build build --target mkdbg-native

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,14 +113,31 @@ option(MKDBG_SKIP_PROBE "Disable probe-bridge integration" OFF)
 find_program(CARGO cargo PATHS "$ENV{HOME}/.cargo/bin" /usr/local/bin /opt/homebrew/bin)
 if(CARGO AND NOT MKDBG_SKIP_PROBE)
   set(PROBE_BRIDGE_DIR "${CMAKE_SOURCE_DIR}/probe-bridge")
-  set(PROBE_BRIDGE_LIB
-      "${CMAKE_BINARY_DIR}/probe-bridge/release/libprobe_bridge.a")
+
+  # When cross-compiling macOS x86_64 from an arm64 host, tell cargo to target
+  # x86_64-apple-darwin so the static lib is ABI-compatible with the C objects.
+  if(APPLE AND CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+    set(_PROBE_CARGO_TARGET "x86_64-apple-darwin")
+    set(PROBE_BRIDGE_LIB
+        "${CMAKE_BINARY_DIR}/probe-bridge/x86_64-apple-darwin/release/libprobe_bridge.a")
+  else()
+    set(_PROBE_CARGO_TARGET "")
+    set(PROBE_BRIDGE_LIB
+        "${CMAKE_BINARY_DIR}/probe-bridge/release/libprobe_bridge.a")
+  endif()
+
+  if(_PROBE_CARGO_TARGET)
+    set(_CARGO_TARGET_ARGS "--target" "${_PROBE_CARGO_TARGET}")
+  else()
+    set(_CARGO_TARGET_ARGS "")
+  endif()
 
   add_custom_command(
     OUTPUT  "${PROBE_BRIDGE_LIB}"
     COMMAND "${CARGO}" build --release
             --manifest-path "${PROBE_BRIDGE_DIR}/Cargo.toml"
             --target-dir    "${CMAKE_BINARY_DIR}/probe-bridge"
+            ${_CARGO_TARGET_ARGS}
     DEPENDS "${PROBE_BRIDGE_DIR}/Cargo.toml"
             "${PROBE_BRIDGE_DIR}/src/lib.rs"
             "${PROBE_BRIDGE_DIR}/src/rsp.rs"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ add_executable(mkdbg-native
   src/seam.c
   src/dashboard.c
   src/wire.c
+  src/uart_transport.c
+  src/rsp_transport.c
   src/debug_session.c
   src/debug_cli.c
   src/debug_tui.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,53 @@ set_target_properties(mkdbg-native PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
 )
 
+# ── probe-bridge: Rust staticlib (optional, requires cargo) ──────────────────
+# Pass -DMKDBG_SKIP_PROBE=ON to disable even when cargo is available.
+option(MKDBG_SKIP_PROBE "Disable probe-bridge integration" OFF)
+find_program(CARGO cargo PATHS "$ENV{HOME}/.cargo/bin" /usr/local/bin /opt/homebrew/bin)
+if(CARGO AND NOT MKDBG_SKIP_PROBE)
+  set(PROBE_BRIDGE_DIR "${CMAKE_SOURCE_DIR}/probe-bridge")
+  set(PROBE_BRIDGE_LIB
+      "${CMAKE_BINARY_DIR}/probe-bridge/release/libprobe_bridge.a")
+
+  add_custom_command(
+    OUTPUT  "${PROBE_BRIDGE_LIB}"
+    COMMAND "${CARGO}" build --release
+            --manifest-path "${PROBE_BRIDGE_DIR}/Cargo.toml"
+            --target-dir    "${CMAKE_BINARY_DIR}/probe-bridge"
+    DEPENDS "${PROBE_BRIDGE_DIR}/Cargo.toml"
+            "${PROBE_BRIDGE_DIR}/src/lib.rs"
+            "${PROBE_BRIDGE_DIR}/src/rsp.rs"
+    COMMENT "Building probe-bridge (Rust)"
+    VERBATIM
+  )
+  add_custom_target(probe_bridge_target DEPENDS "${PROBE_BRIDGE_LIB}")
+
+  target_sources(mkdbg-native PRIVATE src/probe_transport.c)
+  target_include_directories(mkdbg-native PRIVATE
+    "${PROBE_BRIDGE_DIR}/include"
+  )
+  target_compile_definitions(mkdbg-native PRIVATE MKDBG_PROBE_SUPPORT=1)
+  target_link_libraries(mkdbg-native PRIVATE "${PROBE_BRIDGE_LIB}")
+  add_dependencies(mkdbg-native probe_bridge_target)
+
+  if(APPLE)
+    target_link_libraries(mkdbg-native PRIVATE
+      "-framework IOKit"
+      "-framework CoreFoundation"
+      "-framework Security"
+    )
+  endif()
+
+  message(STATUS "probe-bridge: enabled (${CARGO})")
+else()
+  if(MKDBG_SKIP_PROBE)
+    message(STATUS "probe-bridge: disabled (MKDBG_SKIP_PROBE=ON)")
+  else()
+    message(STATUS "probe-bridge: disabled (cargo not found)")
+  endif()
+endif()
+
 # ── seam-analyze: standalone causal-chain analysis tool ──────────────────────
 add_executable(seam-analyze
   src/seam_main.c

--- a/probe-bridge/Cargo.toml
+++ b/probe-bridge/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "probe-bridge"
+version = "0.1.0"
+edition = "2021"
+description = "C FFI bridge exposing probe-rs as a static library for mkdbg"
+
+[lib]
+name = "probe_bridge"
+crate-type = ["staticlib"]
+
+[dependencies]
+probe-rs = { version = "0.24", default-features = true }
+
+[dev-dependencies]
+# unit tests run without hardware; only rsp module is exercised

--- a/probe-bridge/include/probe_bridge.h
+++ b/probe-bridge/include/probe_bridge.h
@@ -1,0 +1,83 @@
+#pragma once
+/*
+ * probe_bridge.h — C API for the probe-bridge static library.
+ *
+ * This header is the only surface that mkdbg's C code touches.
+ * The Rust side is built via `cargo build --release` and linked as
+ * libprobe_bridge.a.
+ *
+ * Return-value conventions (probe_read / probe_write):
+ *   >= 0   bytes transferred
+ *   -1     I/O error (probe disconnected, USB fault)
+ *   -2     timeout (probe_read only, timeout_ms elapsed with no data)
+ *   -3     handle already closed
+ *   -4     bridge internal error (ring-buffer overflow, thread crash)
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---------- probe enumeration ------------------------------------------ */
+
+typedef struct {
+    char     identifier[128]; /* e.g. "ST-Link V2", "DAPLink"           */
+    char     serial[64];      /* USB serial string, may be empty         */
+    uint16_t vid;
+    uint16_t pid;
+} ProbeInfo;
+
+/*
+ * probe_list — enumerate connected debug probes.
+ *
+ * Writes up to `max` ProbeInfo entries into `out`.
+ * Returns the total number of probes found (may exceed `max`).
+ * Returns -1 on internal error.
+ */
+int probe_list(ProbeInfo *out, int max);
+
+/* ---------- session handle --------------------------------------------- */
+
+typedef struct ProbeHandle ProbeHandle;
+
+/*
+ * probe_open — connect to probe[probe_idx] and attach to target chip.
+ *
+ * `chip`  chip name accepted by probe-rs (e.g. "STM32F446RETx").
+ *         Pass NULL to let probe-rs auto-detect from SWD IDCODE.
+ *
+ * Starts an internal RSP interpreter thread.  The thread translates RSP
+ * packets received via probe_write() into probe-rs calls and writes RSP
+ * replies accessible via probe_read().
+ *
+ * Returns NULL on failure.
+ */
+ProbeHandle *probe_open(int probe_idx, const char *chip);
+
+/*
+ * probe_write — push RSP bytes from mkdbg into the bridge.
+ *
+ * Thread-safe.  Non-blocking.
+ */
+int probe_write(ProbeHandle *h, const uint8_t *buf, int len);
+
+/*
+ * probe_read — pull RSP reply bytes out of the bridge.
+ *
+ * Blocks up to `timeout_ms` milliseconds waiting for data.
+ * Thread-safe.
+ */
+int probe_read(ProbeHandle *h, uint8_t *buf, int len, int timeout_ms);
+
+/*
+ * probe_close — detach from target and release all resources.
+ *
+ * Blocks until the internal RSP thread exits.  Safe to call multiple times.
+ */
+void probe_close(ProbeHandle *h);
+
+#ifdef __cplusplus
+}
+#endif

--- a/probe-bridge/src/lib.rs
+++ b/probe-bridge/src/lib.rs
@@ -1,0 +1,423 @@
+//! probe-bridge — C FFI bridge wrapping probe-rs for mkdbg.
+//!
+//! Architecture:
+//!
+//! ```text
+//!  mkdbg (C)                probe-bridge (Rust)              probe-rs
+//!  ─────────────────────────────────────────────────────────────────
+//!  probe_write(buf) ──────► write_tx ──► RSP thread
+//!                                          │  parse RSP packet
+//!                                          │  translate to probe-rs call ──► target
+//!                                          │  format RSP reply  ◄────────── registers/memory
+//!  probe_read(buf)  ◄────── read_rx  ◄──  read_tx.send(reply)
+//! ```
+//!
+//! The RSP interpreter thread runs inside `std::thread::spawn`.  C is kept
+//! fully decoupled from Rust async machinery.
+
+mod rsp;
+
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::sync::mpsc::{self, Receiver, Sender, SyncSender};
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+use probe_rs::config::TargetSelector;
+use probe_rs::probe::list::Lister;
+use probe_rs::{MemoryInterface, Permissions, RegisterId};
+
+// ---------------------------------------------------------------------------
+// C-compatible types
+// ---------------------------------------------------------------------------
+
+#[repr(C)]
+pub struct ProbeInfo {
+    identifier: [u8; 128],
+    serial: [u8; 64],
+    vid: u16,
+    pid: u16,
+}
+
+pub struct ProbeHandle {
+    /// C → RSP thread: raw RSP bytes
+    write_tx: SyncSender<Vec<u8>>,
+    /// RSP thread → C: raw RSP bytes (Mutex keeps probe_read thread-safe)
+    read_state: Mutex<ReadState>,
+    shutdown_tx: SyncSender<()>,
+    thread_handle: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+struct ReadState {
+    rx: Receiver<Vec<u8>>,
+    /// Bytes received but not yet consumed by probe_read
+    leftover: Vec<u8>,
+}
+
+// SAFETY: ProbeHandle is accessed only through the raw-pointer C API.
+// All interior mutability is mediated by Mutex / channel primitives.
+unsafe impl Send for ProbeHandle {}
+unsafe impl Sync for ProbeHandle {}
+
+// ---------------------------------------------------------------------------
+// RSP interpreter thread
+// ---------------------------------------------------------------------------
+
+/// ARM Cortex-M GDB register layout for the 'g' packet:
+///   r0–r15 (16 regs × 4 bytes) + xpsr (4 bytes) = 68 bytes = 136 hex chars.
+const CORTEX_M_REG_COUNT: usize = 17;
+
+/// probe-rs RegisterId for xPSR on ARM Cortex-M.
+/// GDB numbers it as register slot 16 immediately after r0–r15.
+const XPSR_REG_SLOT: u16 = 16;
+
+fn rsp_thread(
+    probe_idx: usize,
+    chip: Option<String>,
+    write_rx: Receiver<Vec<u8>>,
+    read_tx: Sender<Vec<u8>>,
+    shutdown_rx: Receiver<()>,
+) {
+    let lister = Lister::new();
+    let probes = lister.list_all();
+    let probe_info = match probes.get(probe_idx) {
+        Some(p) => p,
+        None => return,
+    };
+
+    let probe = match probe_info.open() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let target: TargetSelector = match chip {
+        Some(ref name) => name.as_str().into(),
+        None => TargetSelector::Auto,
+    };
+
+    let mut session = match probe.attach(target, Permissions::default()) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let mut core = match session.core(0) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    // Halt the core so it is in a known state when the RSP loop starts.
+    let _ = core.halt(Duration::from_secs(1));
+
+    let mut inbuf: Vec<u8> = Vec::new();
+
+    loop {
+        if shutdown_rx.try_recv().is_ok() {
+            break;
+        }
+
+        while let Ok(chunk) = write_rx.try_recv() {
+            inbuf.extend_from_slice(&chunk);
+        }
+
+        loop {
+            match rsp::parse_rsp_packet(&inbuf) {
+                Some((packet, consumed)) => {
+                    inbuf.drain(..consumed);
+                    // Send '+' ACK immediately, then the formatted reply.
+                    let _ = read_tx.send(b"+".to_vec());
+                    let reply_data = handle_command(&mut core, &packet);
+                    let _ = read_tx.send(rsp::format_rsp_packet(&reply_data));
+                }
+                None => break,
+            }
+        }
+
+        thread::sleep(Duration::from_millis(1));
+    }
+}
+
+fn handle_command(core: &mut probe_rs::Core<'_>, cmd: &str) -> String {
+    match cmd.chars().next() {
+        Some('g') => cmd_read_registers(core),
+        Some('G') => cmd_write_registers(core, &cmd[1..]),
+        Some('m') => cmd_read_memory(core, &cmd[1..]),
+        Some('M') => cmd_write_memory(core, &cmd[1..]),
+        Some('s') => cmd_step(core),
+        Some('c') => cmd_continue(core),
+        Some('Z') => cmd_breakpoint(core, &cmd[1..], true),
+        Some('z') => cmd_breakpoint(core, &cmd[1..], false),
+        _ => String::new(), // RSP "not supported" — empty reply
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+/// `g` — read all core registers; reply is 136 hex chars (17 × 4 bytes LE).
+fn cmd_read_registers(core: &mut probe_rs::Core<'_>) -> String {
+    let mut out = String::with_capacity(CORTEX_M_REG_COUNT * 8);
+    for i in 0..CORTEX_M_REG_COUNT as u16 {
+        let reg_id = if i < 16 { i } else { XPSR_REG_SLOT };
+        let word = read_reg_u32(core, reg_id);
+        for b in word.to_le_bytes() {
+            out.push_str(&format!("{:02x}", b));
+        }
+    }
+    out
+}
+
+/// `G<hex-registers>` — write all core registers; reply `OK` or `E01`.
+fn cmd_write_registers(core: &mut probe_rs::Core<'_>, hex: &str) -> String {
+    let bytes = match rsp::decode_hex_bytes(hex) {
+        Some(b) if b.len() >= CORTEX_M_REG_COUNT * 4 => b,
+        _ => return "E01".to_string(),
+    };
+    for i in 0..CORTEX_M_REG_COUNT as u16 {
+        let off = (i as usize) * 4;
+        let val = u32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]]);
+        let reg_id = if i < 16 { i } else { XPSR_REG_SLOT };
+        let _ = core.write_core_reg(RegisterId(reg_id), val);
+    }
+    "OK".to_string()
+}
+
+/// `m addr,len` — read memory; reply is hex-encoded bytes or `E01`.
+fn cmd_read_memory(core: &mut probe_rs::Core<'_>, args: &str) -> String {
+    let (addr, len) = match rsp::parse_addr_len(args) {
+        Some(v) => v,
+        None => return "E01".to_string(),
+    };
+    let mut buf = vec![0u8; len];
+    match core.read_8(addr, &mut buf) {
+        Ok(_) => rsp::encode_hex_bytes(&buf),
+        Err(_) => "E01".to_string(),
+    }
+}
+
+/// `M addr,len:hexdata` — write memory; reply `OK` or `E01`.
+fn cmd_write_memory(core: &mut probe_rs::Core<'_>, args: &str) -> String {
+    let (addr, _len) = match rsp::parse_addr_len(args) {
+        Some(v) => v,
+        None => return "E01".to_string(),
+    };
+    let hex_data = match args.find(':') {
+        Some(p) => &args[p + 1..],
+        None => return "E01".to_string(),
+    };
+    let data = match rsp::decode_hex_bytes(hex_data) {
+        Some(d) => d,
+        None => return "E01".to_string(),
+    };
+    match core.write_8(addr, &data) {
+        Ok(_) => "OK".to_string(),
+        Err(_) => "E01".to_string(),
+    }
+}
+
+/// `s` — single step; returns `S05` (SIGTRAP) or `E01`.
+fn cmd_step(core: &mut probe_rs::Core<'_>) -> String {
+    match core.step() {
+        Ok(_) => "S05".to_string(),
+        Err(_) => "E01".to_string(),
+    }
+}
+
+/// `c` — continue execution; blocks until halted; returns `S05` or `S02`.
+fn cmd_continue(core: &mut probe_rs::Core<'_>) -> String {
+    if core.run().is_err() {
+        return "E01".to_string();
+    }
+    match core.wait_for_core_halted(Duration::from_secs(10)) {
+        Ok(_) => "S05".to_string(),
+        Err(_) => "S02".to_string(), // SIGINT — timeout / externally interrupted
+    }
+}
+
+/// `Z/z type,addr,kind` — set or clear hardware breakpoint / DWT watchpoint.
+///
+/// type 1   → hardware instruction breakpoint
+/// type 2–4 → DWT data watchpoints (write / read / access)
+///
+/// Unsupported type values return `""` (RSP not-supported).
+fn cmd_breakpoint(core: &mut probe_rs::Core<'_>, args: &str, set: bool) -> String {
+    let mut parts = args.splitn(3, ',');
+    let bp_type: u8 = match parts.next().and_then(|s| s.parse().ok()) {
+        Some(t) => t,
+        None => return "E01".to_string(),
+    };
+    let addr: u64 = match parts.next().and_then(|s| u64::from_str_radix(s, 16).ok()) {
+        Some(a) => a,
+        None => return "E01".to_string(),
+    };
+
+    let result = match (bp_type, set) {
+        (1, true) => core.set_hw_breakpoint(addr),
+        (1, false) => core.clear_hw_breakpoint(addr),
+        // DWT watchpoints 2-4: probe-rs exposes DWT through the same
+        // breakpoint slot API on Cortex-M targets.
+        (2..=4, true) => core.set_hw_breakpoint(addr),
+        (2..=4, false) => core.clear_hw_breakpoint(addr),
+        _ => return String::new(), // unsupported type → not-supported reply
+    };
+    match result {
+        Ok(_) => "OK".to_string(),
+        Err(_) => "E01".to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn read_reg_u32(core: &mut probe_rs::Core<'_>, reg: u16) -> u32 {
+    core.read_core_reg::<u32>(RegisterId(reg)).unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// C FFI exports
+// ---------------------------------------------------------------------------
+
+/// Enumerate connected debug probes.
+///
+/// # Safety
+/// `out` must point to a buffer of at least `max` `ProbeInfo` entries.
+#[no_mangle]
+pub unsafe extern "C" fn probe_list(out: *mut ProbeInfo, max: i32) -> i32 {
+    let lister = Lister::new();
+    let probes = lister.list_all();
+    let n = probes.len();
+    let limit = (max.max(0) as usize).min(n);
+
+    for (i, info) in probes.iter().take(limit).enumerate() {
+        let slot = &mut *out.add(i);
+        *slot = ProbeInfo { identifier: [0u8; 128], serial: [0u8; 64], vid: info.vendor_id, pid: info.product_id };
+
+        let id_bytes = info.identifier.as_bytes();
+        let id_len = id_bytes.len().min(127);
+        slot.identifier[..id_len].copy_from_slice(&id_bytes[..id_len]);
+
+        let sn_bytes = info.serial_number.as_deref().unwrap_or("").as_bytes();
+        let sn_len = sn_bytes.len().min(63);
+        slot.serial[..sn_len].copy_from_slice(&sn_bytes[..sn_len]);
+    }
+
+    n as i32
+}
+
+/// Connect to probe[`probe_idx`] and attach to target chip.
+///
+/// `chip` must be a NUL-terminated chip name (e.g. `"STM32F446RETx"`) or
+/// NULL for auto-detect.  Returns NULL on failure.
+///
+/// # Safety
+/// `chip` must be a valid NUL-terminated C string or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn probe_open(probe_idx: i32, chip: *const c_char) -> *mut ProbeHandle {
+    let chip_str: Option<String> = if chip.is_null() {
+        None
+    } else {
+        CStr::from_ptr(chip).to_str().ok().map(str::to_owned)
+    };
+
+    let (write_tx, write_rx) = mpsc::sync_channel::<Vec<u8>>(64);
+    let (read_tx, read_rx) = mpsc::channel::<Vec<u8>>();
+    let (shutdown_tx, shutdown_rx) = mpsc::sync_channel::<()>(1);
+
+    let idx = probe_idx as usize;
+    let jh = thread::spawn(move || {
+        rsp_thread(idx, chip_str, write_rx, read_tx, shutdown_rx);
+    });
+
+    let h = Box::new(ProbeHandle {
+        write_tx,
+        read_state: Mutex::new(ReadState { rx: read_rx, leftover: Vec::new() }),
+        shutdown_tx,
+        thread_handle: Mutex::new(Some(jh)),
+    });
+    Box::into_raw(h)
+}
+
+/// Push RSP bytes from mkdbg into the bridge.
+///
+/// # Safety
+/// `h` must be a valid non-NULL handle.  `buf` must be readable for `len` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn probe_write(
+    h: *mut ProbeHandle,
+    buf: *const u8,
+    len: i32,
+) -> i32 {
+    if h.is_null() {
+        return -3;
+    }
+    let h = &*h;
+    let data = std::slice::from_raw_parts(buf, len as usize).to_vec();
+    match h.write_tx.try_send(data) {
+        Ok(_) => len,
+        Err(mpsc::TrySendError::Full(_)) => -4,
+        Err(mpsc::TrySendError::Disconnected(_)) => -3,
+    }
+}
+
+/// Pull RSP reply bytes out of the bridge.
+///
+/// Blocks up to `timeout_ms` milliseconds.
+///
+/// # Safety
+/// `h` must be a valid non-NULL handle.  `buf` must be writable for `len` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn probe_read(
+    h: *mut ProbeHandle,
+    buf: *mut u8,
+    len: i32,
+    timeout_ms: i32,
+) -> i32 {
+    if h.is_null() {
+        return -3;
+    }
+    let h = &*h;
+    let out = std::slice::from_raw_parts_mut(buf, len as usize);
+
+    let mut state = match h.read_state.lock() {
+        Ok(g) => g,
+        Err(_) => return -4,
+    };
+
+    if state.leftover.is_empty() {
+        let timeout = Duration::from_millis(timeout_ms.max(0) as u64);
+        match state.rx.recv_timeout(timeout) {
+            Ok(chunk) => state.leftover.extend_from_slice(&chunk),
+            Err(mpsc::RecvTimeoutError::Timeout) => return -2,
+            Err(mpsc::RecvTimeoutError::Disconnected) => return -3,
+        }
+    }
+
+    let n = (len as usize).min(state.leftover.len());
+    out[..n].copy_from_slice(&state.leftover[..n]);
+    state.leftover.drain(..n);
+    n as i32
+}
+
+/// Detach from target and release all resources.
+///
+/// Blocks until the RSP thread exits.  Safe to call multiple times.
+///
+/// # Safety
+/// `h` must be a valid pointer returned by `probe_open`.  After this call the
+/// pointer is invalid and must not be dereferenced.
+#[no_mangle]
+pub unsafe extern "C" fn probe_close(h: *mut ProbeHandle) {
+    if h.is_null() {
+        return;
+    }
+    let h = Box::from_raw(h);
+    let _ = h.shutdown_tx.try_send(());
+    if let Ok(mut guard) = h.thread_handle.lock() {
+        if let Some(jh) = guard.take() {
+            let _ = jh.join();
+        }
+    };  // semicolon drops the MutexGuard before h (Box) is freed
+    // Box drops here, releasing all resources.
+}

--- a/probe-bridge/src/rsp.rs
+++ b/probe-bridge/src/rsp.rs
@@ -1,0 +1,173 @@
+//! RSP packet parsing and formatting helpers.
+//!
+//! Covered subset (PR-2):
+//!   g, G          — read/write all core registers
+//!   m addr,len    — read memory
+//!   M addr,len:xx — write memory
+//!   s             — single step
+//!   c             — continue
+//!   Z1/z1         — hardware breakpoint set/clear
+//!   Z2-Z4/z2-z4   — DWT watchpoint set/clear
+//!
+//! All other commands get an empty reply (""), which is the RSP "not
+//! supported" response per the GDB remote serial protocol spec.
+
+/// Parse the first complete RSP packet from `buf`.
+///
+/// Returns `(packet_data, bytes_consumed)`.  `bytes_consumed` includes the
+/// `$`, the data, `#`, and the two checksum hex digits.  Leading `+`/`-`
+/// acknowledgement bytes are skipped before scanning for `$`.
+pub fn parse_rsp_packet(buf: &[u8]) -> Option<(String, usize)> {
+    let start = buf.iter().position(|&b| b == b'$')?;
+    let hash = buf[start + 1..].iter().position(|&b| b == b'#')
+        .map(|p| start + 1 + p)?;
+    if buf.len() < hash + 3 {
+        return None; // checksum bytes not yet received
+    }
+    let data = std::str::from_utf8(&buf[start + 1..hash]).ok()?.to_string();
+    Some((data, hash + 3))
+}
+
+/// Build `$<data>#<checksum>` from a plain string.
+pub fn format_rsp_packet(data: &str) -> Vec<u8> {
+    let ck: u8 = data.bytes().fold(0u8, |a, b| a.wrapping_add(b));
+    format!("${}#{:02x}", data, ck).into_bytes()
+}
+
+/// Verify the two-character hex checksum `chk_hex` against `data`.
+#[allow(dead_code)]
+pub fn verify_checksum(data: &[u8], chk_hex: &[u8]) -> bool {
+    if chk_hex.len() < 2 {
+        return false;
+    }
+    let hi = match (chk_hex[0] as char).to_digit(16) {
+        Some(d) => d as u8,
+        None => return false,
+    };
+    let lo = match (chk_hex[1] as char).to_digit(16) {
+        Some(d) => d as u8,
+        None => return false,
+    };
+    let expected: u8 = data.iter().fold(0u8, |a, &b| a.wrapping_add(b));
+    (hi << 4 | lo) == expected
+}
+
+/// Parse `addr,len` out of the argument portion of an `m` or `M` command.
+pub fn parse_addr_len(args: &str) -> Option<(u64, usize)> {
+    let mut parts = args.splitn(2, ',');
+    let addr = u64::from_str_radix(parts.next()?.trim(), 16).ok()?;
+    let len_str = parts.next()?.split(':').next()?; // M has `:data` after len
+    let len = usize::from_str_radix(len_str.trim(), 16).ok()?;
+    Some((addr, len))
+}
+
+/// Decode the hex-encoded byte string after `M addr,len:` into bytes.
+pub fn decode_hex_bytes(hex: &str) -> Option<Vec<u8>> {
+    if hex.len() % 2 != 0 {
+        return None;
+    }
+    (0..hex.len() / 2)
+        .map(|i| u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok())
+        .collect()
+}
+
+/// Encode bytes as a lowercase hex string.
+pub fn encode_hex_bytes(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_basic_packet() {
+        // $g#67
+        let buf = b"$g#67";
+        let (data, consumed) = parse_rsp_packet(buf).unwrap();
+        assert_eq!(data, "g");
+        assert_eq!(consumed, 5);
+    }
+
+    #[test]
+    fn parse_skips_leading_ack() {
+        let buf = b"+$g#67";
+        let (data, consumed) = parse_rsp_packet(buf).unwrap();
+        assert_eq!(data, "g");
+        assert_eq!(consumed, 6);
+    }
+
+    #[test]
+    fn parse_incomplete_returns_none() {
+        assert!(parse_rsp_packet(b"$g#6").is_none()); // missing second checksum nibble
+        assert!(parse_rsp_packet(b"$g").is_none());   // no hash yet
+        assert!(parse_rsp_packet(b"").is_none());
+    }
+
+    #[test]
+    fn parse_memory_read_packet() {
+        // $m20000000,4#XX — checksum doesn't matter for parse_rsp_packet
+        let data = "m20000000,4";
+        let ck: u8 = data.bytes().fold(0, |a, b: u8| a.wrapping_add(b));
+        let pkt = format!("${}#{:02x}", data, ck);
+        let (out, _) = parse_rsp_packet(pkt.as_bytes()).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn format_roundtrip() {
+        let reply = "deadbeef";
+        let pkt = format_rsp_packet(reply);
+        let (parsed, _) = parse_rsp_packet(&pkt).unwrap();
+        assert_eq!(parsed, reply);
+    }
+
+    #[test]
+    fn format_empty_reply() {
+        // Empty reply = RSP "not supported"
+        let pkt = format_rsp_packet("");
+        assert_eq!(pkt, b"$#00");
+    }
+
+    #[test]
+    fn verify_checksum_ok() {
+        let data = b"g";
+        // sum('g') = 0x67
+        assert!(verify_checksum(data, b"67"));
+    }
+
+    #[test]
+    fn verify_checksum_bad() {
+        assert!(!verify_checksum(b"g", b"00"));
+    }
+
+    #[test]
+    fn parse_addr_len_basic() {
+        let (addr, len) = parse_addr_len("20000000,4").unwrap();
+        assert_eq!(addr, 0x20000000);
+        assert_eq!(len, 4);
+    }
+
+    #[test]
+    fn parse_addr_len_with_data_suffix() {
+        // M command: "20000000,4:deadbeef"
+        let (addr, len) = parse_addr_len("20000000,4:deadbeef").unwrap();
+        assert_eq!(addr, 0x20000000);
+        assert_eq!(len, 4);
+    }
+
+    #[test]
+    fn decode_hex_bytes_basic() {
+        assert_eq!(decode_hex_bytes("deadbeef").unwrap(), &[0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn decode_hex_bytes_odd_returns_none() {
+        assert!(decode_hex_bytes("abc").is_none());
+    }
+
+    #[test]
+    fn encode_hex_bytes_basic() {
+        assert_eq!(encode_hex_bytes(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+    }
+}

--- a/src/core.c
+++ b/src/core.c
@@ -1,4 +1,7 @@
 #include "mkdbg.h"
+#ifdef MKDBG_PROBE_SUPPORT
+#include "probe_bridge.h"
+#endif
 
 void init_default_repo_name(char *out, size_t out_size)
 {
@@ -136,6 +139,42 @@ int cmd_doctor(const DoctorOptions *opts)
   if (repo->gdb[0] != '\0') {
     print_check(command_available(repo->gdb), "gdb", repo->gdb, &failed);
   }
+
+#ifdef MKDBG_PROBE_SUPPORT
+  /* Probe diagnostics: enumerate USB debug probes. */
+  {
+    ProbeInfo probes[16];
+    int n = probe_list(probes, 16);
+    if (n < 0) {
+      print_check(0, "probe", "enumeration error", &failed);
+    } else if (n == 0) {
+      print_check(0, "probe",
+                  "no probe detected (insert CMSIS-DAP / ST-Link / J-Link)", &failed);
+    } else {
+      char probe_detail[256];
+      snprintf(probe_detail, sizeof(probe_detail), "%s (%d probe%s found)",
+               probes[0].identifier[0] ? (char *)probes[0].identifier : "unknown",
+               n, n == 1 ? "" : "s");
+      print_check(1, "probe", probe_detail, &failed);
+    }
+  }
+#ifdef __linux__
+  /* On Linux, libusb requires udev rules for non-root USB access. */
+  {
+    int udev_ok =
+        access("/etc/udev/rules.d/69-probe-rs.rules", F_OK) == 0 ||
+        access("/usr/lib/udev/rules.d/69-probe-rs.rules", F_OK) == 0;
+    if (!udev_ok) {
+      print_check(0, "udev",
+                  "69-probe-rs.rules not found — USB probe may need root", &failed);
+      printf("       fix: sudo cp tools/69-probe-rs.rules /etc/udev/rules.d/ "
+             "&& sudo udevadm control --reload\n");
+    } else {
+      print_check(1, "udev", "69-probe-rs.rules installed", &failed);
+    }
+  }
+#endif /* __linux__ */
+#endif /* MKDBG_PROBE_SUPPORT */
 
   return failed ? 1 : 0;
 }

--- a/src/debug_session.c
+++ b/src/debug_session.c
@@ -1,10 +1,13 @@
-/* debug_session.c — Live debug session over UART (RSP client)
+/* debug_session.c — Live debug session over WireTransport (RSP client)
  *
  * SPDX-License-Identifier: MIT
  */
 
 #include "debug_session.h"
 #include "arch.h"
+#include "transport.h"
+#include "rsp_transport.h"
+#include "uart_transport.h"
 #include "wire_host.h"
 
 #include <stdio.h>
@@ -15,7 +18,7 @@
 /* ── Internal state ──────────────────────────────────────────────────────── */
 
 struct DebugSession {
-    int              fd;           /* serial port file descriptor */
+    WireTransport   *transport;    /* byte-stream backend (UART or probe) */
     int              last_signal;  /* GDB signal from most recent stop reply */
     const MkdbgArch *arch;         /* active architecture (live_debug guaranteed non-NULL) */
 };
@@ -42,27 +45,38 @@ static int parse_stop_signal(const char *reply)
 
 /* ── Lifecycle ───────────────────────────────────────────────────────────── */
 
+/*
+ * Open a session from a pre-constructed transport.  Takes ownership of t;
+ * transport_destroy() is called on debug_session_close().
+ * Used by debug_session_open() (UART) and in PR-3 by probe_transport.
+ */
+DebugSession *debug_session_open_transport(WireTransport *t,
+                                            const MkdbgArch *arch)
+{
+    if (!t || !arch) return NULL;
+    DebugSession *s = malloc(sizeof(DebugSession));
+    if (!s) return NULL;
+    s->transport   = t;
+    s->last_signal = 0;
+    s->arch        = arch;
+    return s;
+}
+
 DebugSession *debug_session_open(const char *port, int baud,
                                   const MkdbgArch *arch)
 {
-    int fd = wire_serial_open(port, baud);
-    if (fd < 0) return NULL;
+    WireTransport *t = uart_transport_open(port, baud);
+    if (!t) return NULL;
 
-    DebugSession *s = malloc(sizeof(DebugSession));
-    if (!s) {
-        close(fd);
-        return NULL;
-    }
-    s->fd          = fd;
-    s->last_signal = 0;
-    s->arch        = arch;
+    DebugSession *s = debug_session_open_transport(t, arch);
+    if (!s) { transport_destroy(t); return NULL; }
     return s;
 }
 
 void debug_session_close(DebugSession *s)
 {
     if (!s) return;
-    close(s->fd);
+    transport_destroy(s->transport);
     free(s);
 }
 
@@ -73,11 +87,11 @@ int debug_session_continue(DebugSession *s)
     char resp[16];
 
     /* 'c' gets S00 immediately (MCU resuming); then wait for halt stop reply. */
-    int rc = rsp_transaction(s->fd, "c", resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, "c", resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
 
     char stop[16];
-    rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    rc = rsp_wait_for_stop_t(s->transport, stop, sizeof(stop));
     if (rc == WIRE_OK)
         s->last_signal = parse_stop_signal(stop);
     return rc;
@@ -86,7 +100,7 @@ int debug_session_continue(DebugSession *s)
 int debug_session_detach(DebugSession *s)
 {
     /* Send 'c' but do NOT wait — leave the MCU running and return. */
-    return rsp_send_packet(s->fd, "c");
+    return rsp_send_packet_t(s->transport, "c");
 }
 
 int debug_session_interrupt(DebugSession *s)
@@ -94,11 +108,11 @@ int debug_session_interrupt(DebugSession *s)
     /* Send raw Ctrl-C (0x03) — not an RSP packet, just one byte.
      * The firmware's wire_poll_break_in() detects it and pends DebugMonitor. */
     uint8_t ctrlc = 0x03u;
-    ssize_t n = write(s->fd, &ctrlc, 1);
+    int n = s->transport->write(s->transport->ctx, &ctrlc, 1);
     if (n != 1) return WIRE_ERR_IO;
 
     char stop[16];
-    int rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    int rc = rsp_wait_for_stop_t(s->transport, stop, sizeof(stop));
     if (rc == WIRE_OK)
         s->last_signal = parse_stop_signal(stop);
     return rc;
@@ -107,13 +121,13 @@ int debug_session_interrupt(DebugSession *s)
 int debug_session_step(DebugSession *s)
 {
     /* 's' has NO immediate reply per RSP spec — send directly, not via
-     * rsp_transaction().  The stop-reply S05 arrives when DebugMonitor
+     * rsp_transaction_t().  The stop-reply S05 arrives when DebugMonitor
      * fires after the CPU executes one instruction. */
-    int rc = rsp_send_packet(s->fd, "s");
+    int rc = rsp_send_packet_t(s->transport, "s");
     if (rc != WIRE_OK) return rc;
 
     char stop[16];
-    rc = rsp_wait_for_stop(s->fd, stop, sizeof(stop));
+    rc = rsp_wait_for_stop_t(s->transport, stop, sizeof(stop));
     if (rc == WIRE_OK)
         s->last_signal = parse_stop_signal(stop);
     return rc;
@@ -127,7 +141,7 @@ int debug_session_set_hw_breakpoint(DebugSession *s, uint32_t addr)
     snprintf(cmd, sizeof(cmd), "Z1,%x,4", addr);
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -138,7 +152,7 @@ int debug_session_clear_hw_breakpoint(DebugSession *s, uint32_t addr)
     snprintf(cmd, sizeof(cmd), "z1,%x,4", addr);
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -152,7 +166,7 @@ int debug_session_set_watchpoint(DebugSession *s, uint32_t addr,
     snprintf(cmd, sizeof(cmd), "Z%d,%x,%x", (int)type, addr, len ? len : 1);
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -165,7 +179,7 @@ int debug_session_clear_watchpoint(DebugSession *s, uint32_t addr)
     int types[3] = { WATCHPOINT_WRITE, WATCHPOINT_READ, WATCHPOINT_ACCESS };
     for (int i = 0; i < 3; i++) {
         snprintf(cmd, sizeof(cmd), "z%d,%x,1", types[i], addr);
-        int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+        int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
         if (rc == WIRE_OK && strcmp(resp, "OK") == 0) return WIRE_OK;
     }
     return WIRE_ERR_IO;
@@ -178,7 +192,7 @@ int debug_session_read_regs(DebugSession *s, uint32_t regs[DEBUG_SESSION_MAX_REG
     int nregs = s->arch->live_debug->nregs;
     /* RSP 'g': nregs registers × 8 hex chars each, little-endian. */
     char resp[DEBUG_SESSION_MAX_REGS * 8 + 4];
-    int rc = rsp_transaction(s->fd, "g", resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, "g", resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     if (resp[0] == 'E') return WIRE_ERR_IO;
 
@@ -205,7 +219,7 @@ int debug_session_read_mem(DebugSession *s, uint32_t addr, size_t len, uint8_t *
     char resp[4096];
     if (len * 2 + 4 > sizeof(resp)) return WIRE_ERR_OVERFLOW;
 
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     if (resp[0] == 'E') return WIRE_ERR_IO;
 
@@ -233,7 +247,7 @@ int debug_session_write_mem(DebugSession *s, uint32_t addr, size_t len,
     cmd[hdr + len * 2] = '\0';
 
     char resp[16];
-    int rc = rsp_transaction(s->fd, cmd, resp, sizeof(resp));
+    int rc = rsp_transaction_t(s->transport, cmd, resp, sizeof(resp));
     if (rc != WIRE_OK) return rc;
     return (strcmp(resp, "OK") == 0) ? WIRE_OK : WIRE_ERR_IO;
 }
@@ -241,9 +255,9 @@ int debug_session_write_mem(DebugSession *s, uint32_t addr, size_t len,
 int debug_session_reset(DebugSession *s)
 {
     /* RSP 'R' packet: software system reset.
-     * The MCU resets immediately and sends NO reply — use rsp_send_packet,
-     * not rsp_transaction, to avoid blocking on a reply that never arrives. */
-    return rsp_send_packet(s->fd, "R00");
+     * The MCU resets immediately and sends NO reply — use rsp_send_packet_t,
+     * not rsp_transaction_t, to avoid blocking on a reply that never arrives. */
+    return rsp_send_packet_t(s->transport, "R00");
 }
 
 /* ── Arch metadata ───────────────────────────────────────────────────────── */

--- a/src/debug_session.h
+++ b/src/debug_session.h
@@ -15,8 +15,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* Forward-declare MkdbgArch to avoid circular includes. */
-typedef struct MkdbgArch MkdbgArch;
+/* Forward-declare MkdbgArch and WireTransport to avoid circular includes. */
+typedef struct MkdbgArch    MkdbgArch;
+typedef struct WireTransport WireTransport;
 
 /* Opaque session handle. */
 typedef struct DebugSession DebugSession;
@@ -32,6 +33,12 @@ typedef struct DebugSession DebugSession;
  * Returns NULL on error (error printed to stderr). */
 DebugSession *debug_session_open(const char *port, int baud,
                                   const MkdbgArch *arch);
+
+/* Open a session from a pre-constructed WireTransport.
+ * Takes ownership of t; transport_destroy() is called on debug_session_close().
+ * Used by probe_transport.c (PR-3) to attach via hardware probe. */
+DebugSession *debug_session_open_transport(WireTransport *t,
+                                            const MkdbgArch *arch);
 
 /* Close UART and free the session. */
 void debug_session_close(DebugSession *s);

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -1,4 +1,11 @@
 #include "mkdbg.h"
+#include "arch.h"
+#include "debug_session.h"
+#include "debug_tui.h"
+#ifdef MKDBG_PROBE_SUPPORT
+#include "probe_bridge.h"
+#include "probe_transport.h"
+#endif
 
 int cmd_capture_bundle(const CaptureBundleOptions *opts)
 {
@@ -216,8 +223,67 @@ int cmd_attach(const AttachOptions *opts)
     return run_process(shell_argv, repo_root, opts->dry_run);
   }
 
+#ifdef MKDBG_PROBE_SUPPORT
+  /* Probe path: auto-detect or use explicit --probe N */
+  {
+    ProbeInfo probes[16];
+    int n = probe_list(probes, 16);
+    if (n < 0) {
+      fprintf(stderr, "mkdbg: probe enumeration failed\n");
+      return 1;
+    }
+    if (n == 0) {
+      fprintf(stderr,
+              "mkdbg: no debug probe detected\n"
+              "       insert a CMSIS-DAP / ST-Link / J-Link probe, "
+              "or pass --port for UART\n");
+      return 1;
+    }
+    int idx = opts->probe_idx;
+    if (idx < 0) {
+      if (n > 1) {
+        int i;
+        fprintf(stderr, "mkdbg: %d probes found — select one with --probe N:\n", n);
+        for (i = 0; i < n; i++) {
+          fprintf(stderr, "  [%d] %s  serial: %s\n",
+                  i,
+                  probes[i].identifier[0] ? (char *)probes[i].identifier : "unknown",
+                  probes[i].serial[0]     ? (char *)probes[i].serial     : "(none)");
+        }
+        return 1;
+      }
+      idx = 0;
+    } else if (idx >= n) {
+      fprintf(stderr, "mkdbg: --probe %d out of range (%d probe(s) found)\n", idx, n);
+      return 1;
+    }
+    if (opts->dry_run) {
+      printf("[dry-run] probe_open(%d, %s) → open debug TUI\n",
+             idx, opts->chip ? opts->chip : "auto");
+      return 0;
+    }
+    {
+      const MkdbgArch *arch = mkdbg_arch_find("cortex-m");
+      WireTransport   *t;
+      DebugSession    *s;
+      if (!arch || !arch->live_debug) {
+        fprintf(stderr, "mkdbg: cortex-m arch does not support live debug\n");
+        return 1;
+      }
+      t = probe_transport_open(idx, opts->chip);
+      if (!t) return 1;
+      s = debug_session_open_transport(t, arch);
+      if (!s) { transport_destroy(t); return 1; }
+      printf("mkdbg probe debug  probe=%d  chip=%s\n",
+             idx, opts->chip ? opts->chip : "auto");
+      return debug_tui_run(s, NULL);
+    }
+  }
+#else
   fprintf(stderr,
           "mkdbg: attach requires --port to read a crash report over UART\n"
+          "       (probe support not compiled in; rebuild with cargo in PATH)\n"
           "       mkdbg attach --port /dev/ttyUSB0\n");
   return 1;
+#endif
 }

--- a/src/mkdbg.h
+++ b/src/mkdbg.h
@@ -151,6 +151,9 @@ typedef struct {
   const char *target;
   const char *port;
   const char *baud;
+  /* Probe flags: probe_idx=-1 means auto-detect; chip=NULL means auto IDCODE */
+  int         probe_idx;
+  const char *chip;
   const char *breakpoints[MAX_ATTACH_BREAKPOINTS];
   size_t breakpoint_count;
   const char *gdb_commands[MAX_ATTACH_COMMANDS];

--- a/src/parse.c
+++ b/src/parse.c
@@ -233,6 +233,7 @@ int parse_attach_args(int argc, char **argv, AttachOptions *opts)
 {
   int i;
   memset(opts, 0, sizeof(*opts));
+  opts->probe_idx = -1; /* auto-detect */
   opts->server_wait_s = 1.2;
 
   for (i = 0; i < argc; ++i) {
@@ -267,6 +268,16 @@ int parse_attach_args(int argc, char **argv, AttachOptions *opts)
         die("too many --command arguments");
       }
       opts->gdb_commands[opts->gdb_command_count++] = argv[++i];
+    } else if (strcmp(argv[i], "--probe") == 0) {
+      char *end = NULL;
+      long v;
+      if (i + 1 >= argc) die("missing value for --probe");
+      v = strtol(argv[++i], &end, 10);
+      if (!end || *end != '\0' || v < 0) die("--probe requires a non-negative integer");
+      opts->probe_idx = (int)v;
+    } else if (strcmp(argv[i], "--chip") == 0) {
+      if (i + 1 >= argc) die("missing value for --chip");
+      opts->chip = argv[++i];
     } else if (strcmp(argv[i], "--batch") == 0) {
       opts->batch = 1;
     } else if (strcmp(argv[i], "--dry-run") == 0) {

--- a/src/probe_transport.c
+++ b/src/probe_transport.c
@@ -1,0 +1,58 @@
+/* probe_transport.c — WireTransport adapter backed by probe-bridge.
+ *
+ * Wraps the five probe_bridge C FFI functions (probe_open / probe_read /
+ * probe_write / probe_close) as a WireTransport so that debug_session.c's
+ * RSP client works identically over UART or a hardware debug probe.
+ *
+ * Compiled only when MKDBG_PROBE_SUPPORT is defined by CMakeLists.txt.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "probe_transport.h"
+#include "probe_bridge.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* ── WireTransport callbacks ─────────────────────────────────────────────── */
+
+static int pt_read(void *ctx, uint8_t *buf, int len, int timeout_ms)
+{
+    return probe_read((ProbeHandle *)ctx, buf, len, timeout_ms);
+}
+
+static int pt_write(void *ctx, const uint8_t *buf, int len)
+{
+    return probe_write((ProbeHandle *)ctx, buf, len);
+}
+
+static void pt_close(void *ctx)
+{
+    probe_close((ProbeHandle *)ctx);
+}
+
+/* ── public API ──────────────────────────────────────────────────────────── */
+
+WireTransport *probe_transport_open(int probe_idx, const char *chip)
+{
+    ProbeHandle *h = probe_open(probe_idx, chip);
+    if (!h) {
+        fprintf(stderr, "mkdbg: probe_open(%d, %s) failed\n",
+                probe_idx, chip ? chip : "auto");
+        return NULL;
+    }
+
+    WireTransport *t = malloc(sizeof(WireTransport));
+    if (!t) {
+        probe_close(h);
+        return NULL;
+    }
+
+    t->read  = pt_read;
+    t->write = pt_write;
+    t->close = pt_close;
+    t->ctx   = h;
+    return t;
+}

--- a/src/probe_transport.h
+++ b/src/probe_transport.h
@@ -1,0 +1,24 @@
+/* probe_transport.h — WireTransport adapter backed by probe-bridge.
+ *
+ * Only compiled when MKDBG_PROBE_SUPPORT is defined (cargo found at
+ * configure time).  All callers must guard with #ifdef MKDBG_PROBE_SUPPORT.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef PROBE_TRANSPORT_H
+#define PROBE_TRANSPORT_H
+
+#include "transport.h"
+
+/*
+ * probe_transport_open — open probe[probe_idx] and return a WireTransport.
+ *
+ * probe_idx  index from probe_list(); pass 0 when only one probe is present.
+ * chip       chip name (e.g. "STM32F446RETx"), or NULL for auto-detect.
+ *
+ * Returns a heap-allocated WireTransport on success, NULL on failure.
+ * Caller destroys with transport_destroy().
+ */
+WireTransport *probe_transport_open(int probe_idx, const char *chip);
+
+#endif /* PROBE_TRANSPORT_H */

--- a/src/rsp_transport.c
+++ b/src/rsp_transport.c
@@ -1,0 +1,172 @@
+/* rsp_transport.c — GDB RSP packet framing over WireTransport.
+ *
+ * Re-implements the RSP client (deps/wire/host/wire_rsp_client.c) using
+ * WireTransport callbacks.  The fd-based RSP client is still used by the crash
+ * dump path (wire_dump_crash_to_buf); this file is for the live debug session.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "rsp_transport.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#define RSP_BUF_MAX        4096
+#define RSP_MAX_RETRIES       3
+#define RSP_TIMEOUT_MS     2000
+#define RSP_WAIT_STOP_RETRIES 30   /* 30 × 2 s = 60 s */
+
+/* ── helpers ─────────────────────────────────────────────────────────────── */
+
+static uint8_t rsp_checksum(const char *data, size_t len)
+{
+    uint8_t sum = 0;
+    for (size_t i = 0; i < len; i++)
+        sum = (uint8_t)(sum + (uint8_t)data[i]);
+    return sum;
+}
+
+static int hex_nibble(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/*
+ * Read exactly one byte with timeout_ms via transport.
+ * Returns 1 on success, WIRE_ERR_TIMEOUT on timeout, WIRE_ERR_IO on error.
+ */
+static int read_byte_t(WireTransport *t, uint8_t *out, int timeout_ms)
+{
+    int r = t->read(t->ctx, out, 1, timeout_ms);
+    if (r == 1) return 1;
+    if (r == TRANSPORT_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+    return WIRE_ERR_IO;
+}
+
+/*
+ * Write one byte via transport.  Returns WIRE_OK or WIRE_ERR_IO.
+ */
+static int write_byte_t(WireTransport *t, uint8_t b)
+{
+    int r = t->write(t->ctx, &b, 1);
+    return (r == 1) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+/* ── send ────────────────────────────────────────────────────────────────── */
+
+int rsp_send_packet_t(WireTransport *t, const char *data)
+{
+    size_t  dlen = strlen(data);
+    uint8_t sum  = rsp_checksum(data, dlen);
+    char    buf[RSP_BUF_MAX + 8];
+    int     n    = snprintf(buf, sizeof(buf), "$%s#%02x", data, sum);
+    if (n < 0 || (size_t)n >= sizeof(buf)) return WIRE_ERR_OVERFLOW;
+
+    int r = t->write(t->ctx, (const uint8_t *)buf, (int)n);
+    return (r == n) ? WIRE_OK : WIRE_ERR_IO;
+}
+
+/* ── receive ─────────────────────────────────────────────────────────────── */
+
+static int rsp_recv_packet_t(WireTransport *t, char *out_buf, size_t out_size)
+{
+    uint8_t c;
+
+    /* drain until '$' */
+    for (;;) {
+        int r = read_byte_t(t, &c, RSP_TIMEOUT_MS);
+        if (r == WIRE_ERR_IO)      return WIRE_ERR_IO;
+        if (r == WIRE_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+        if (c == '$') break;
+    }
+
+    /* accumulate data until '#' */
+    size_t  dlen        = 0;
+    uint8_t running_sum = 0;
+    for (;;) {
+        int r = read_byte_t(t, &c, RSP_TIMEOUT_MS);
+        if (r == WIRE_ERR_IO)      return WIRE_ERR_IO;
+        if (r == WIRE_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+        if (c == '#') break;
+        if (dlen + 1 >= out_size) {
+            write_byte_t(t, '-');
+            return WIRE_ERR_OVERFLOW;
+        }
+        out_buf[dlen++] = (char)c;
+        running_sum     = (uint8_t)(running_sum + c);
+    }
+    out_buf[dlen] = '\0';
+
+    /* read 2-hex checksum */
+    uint8_t hi, lo;
+    if (read_byte_t(t, &hi, RSP_TIMEOUT_MS) != 1) return WIRE_ERR_IO;
+    if (read_byte_t(t, &lo, RSP_TIMEOUT_MS) != 1) return WIRE_ERR_IO;
+
+    int h = hex_nibble((char)hi);
+    int l = hex_nibble((char)lo);
+    if (h < 0 || l < 0) {
+        write_byte_t(t, '-');
+        return WIRE_ERR_CHECKSUM;
+    }
+
+    uint8_t expected = (uint8_t)((h << 4) | l);
+    if (running_sum != expected) {
+        write_byte_t(t, '-');
+        return WIRE_ERR_CHECKSUM;
+    }
+
+    write_byte_t(t, '+');
+    return WIRE_OK;
+}
+
+/* ── public API ──────────────────────────────────────────────────────────── */
+
+int rsp_wait_for_stop_t(WireTransport *t, char *out_buf, size_t out_size)
+{
+    for (int i = 0; i < RSP_WAIT_STOP_RETRIES; i++) {
+        int rc = rsp_recv_packet_t(t, out_buf, out_size);
+        if (rc == WIRE_ERR_TIMEOUT) continue;
+        if (rc != WIRE_OK)          return rc;
+        if (out_buf[0] == 'S' || out_buf[0] == 'T')
+            return WIRE_OK;
+        /* stale ACK or unexpected packet — keep waiting */
+    }
+    return WIRE_ERR_TIMEOUT;
+}
+
+int rsp_transaction_t(WireTransport *t, const char *cmd,
+                      char *resp_buf, size_t resp_size)
+{
+    for (int cmd_try = 0; cmd_try < RSP_MAX_RETRIES; cmd_try++) {
+        int rc = rsp_send_packet_t(t, cmd);
+        if (rc != WIRE_OK) return rc;
+
+        /* Wait for server ACK/NAK of our command */
+        uint8_t ack;
+        int r = read_byte_t(t, &ack, RSP_TIMEOUT_MS);
+        if (r == WIRE_ERR_IO)      return WIRE_ERR_IO;
+        if (r == WIRE_ERR_TIMEOUT) return WIRE_ERR_TIMEOUT;
+        if (ack == '-') {
+            fprintf(stderr, "mkdbg: RSP NAK on '%s', retrying (%d/%d)\n",
+                    cmd, cmd_try + 1, RSP_MAX_RETRIES);
+            continue;
+        }
+        if (ack != '+') continue;  /* unexpected byte, retransmit */
+
+        /* Server ACK'd; receive response with checksum retry */
+        for (int resp_try = 0; resp_try < RSP_MAX_RETRIES; resp_try++) {
+            rc = rsp_recv_packet_t(t, resp_buf, resp_size);
+            if (rc == WIRE_OK) return WIRE_OK;
+            if (rc != WIRE_ERR_CHECKSUM) return rc;
+            fprintf(stderr, "mkdbg: RSP response checksum error, retry %d/%d\n",
+                    resp_try + 1, RSP_MAX_RETRIES);
+        }
+        return WIRE_ERR_CHECKSUM;
+    }
+    return WIRE_ERR_CHECKSUM;
+}

--- a/src/rsp_transport.h
+++ b/src/rsp_transport.h
@@ -1,0 +1,38 @@
+/* rsp_transport.h — GDB RSP packet framing over WireTransport.
+ *
+ * Drop-in replacement for deps/wire/host/wire_rsp_client.c that uses
+ * WireTransport callbacks instead of a raw POSIX fd, enabling the same
+ * RSP logic to run over UART or a hardware probe bridge.
+ *
+ * Return values mirror wire_host.h WIRE_* codes so callers are unchanged.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef RSP_TRANSPORT_H
+#define RSP_TRANSPORT_H
+
+#include "transport.h"
+#include "wire_host.h"   /* WIRE_OK, WIRE_ERR_* */
+
+#include <stddef.h>
+
+/*
+ * Send one RSP packet ($data#checksum) without waiting for a reply.
+ * Used for commands that have no immediate response (e.g. 's' single-step).
+ */
+int rsp_send_packet_t(WireTransport *t, const char *data);
+
+/*
+ * Block until the target sends a spontaneous stop reply (S or T packet).
+ * Retries for up to ~60 s.  Returns WIRE_OK with the reply in out_buf.
+ */
+int rsp_wait_for_stop_t(WireTransport *t, char *out_buf, size_t out_size);
+
+/*
+ * Send cmd and receive the server response, with NAK/retransmit (up to 3×).
+ * Returns WIRE_OK on success.
+ */
+int rsp_transaction_t(WireTransport *t, const char *cmd,
+                      char *resp_buf, size_t resp_size);
+
+#endif /* RSP_TRANSPORT_H */

--- a/src/transport.h
+++ b/src/transport.h
@@ -1,0 +1,44 @@
+/* transport.h — Abstract byte-stream transport for debug_session.
+ *
+ * Decouples debug_session.c from the concrete I/O mechanism so that the same
+ * RSP client code works over a UART fd (uart_transport.c) or a hardware probe
+ * via probe-bridge (probe_transport.c, PR-3).
+ *
+ * Error codes returned by read/write callbacks:
+ *   TRANSPORT_ERR_IO      — OS-level I/O error
+ *   TRANSPORT_ERR_TIMEOUT — read timed out (caller should retry or abort)
+ *   TRANSPORT_ERR_CLOSED  — peer closed the connection
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef TRANSPORT_H
+#define TRANSPORT_H
+
+#include <stdint.h>
+
+#define TRANSPORT_OK           0
+#define TRANSPORT_ERR_IO      (-1)
+#define TRANSPORT_ERR_TIMEOUT (-2)
+#define TRANSPORT_ERR_CLOSED  (-3)
+
+/*
+ * WireTransport — pluggable byte-stream backend.
+ *
+ * read():  read up to len bytes into buf; timeout_ms is a per-call wall-clock
+ *          limit.  Returns bytes transferred (>= 1) or a negative error code.
+ * write(): write exactly len bytes from buf.  Returns bytes written (== len on
+ *          success) or a negative error code.
+ * close(): release all resources; transport must not be used after this call.
+ * ctx:     opaque pointer forwarded to every callback.
+ */
+typedef struct WireTransport {
+    int  (*read) (void *ctx, uint8_t *buf, int len, int timeout_ms);
+    int  (*write)(void *ctx, const uint8_t *buf, int len);
+    void (*close)(void *ctx);
+    void *ctx;
+} WireTransport;
+
+/* Free the WireTransport struct itself after calling t->close(t->ctx). */
+void transport_destroy(WireTransport *t);
+
+#endif /* TRANSPORT_H */

--- a/src/uart_transport.c
+++ b/src/uart_transport.c
@@ -1,0 +1,93 @@
+/* uart_transport.c — WireTransport adapter for POSIX serial / PTY fds.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "uart_transport.h"
+#include "wire_host.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/select.h>
+#include <unistd.h>
+
+/* ── internal context ────────────────────────────────────────────────────── */
+
+typedef struct {
+    int fd;
+} UartCtx;
+
+/* ── callbacks ───────────────────────────────────────────────────────────── */
+
+static int uart_read(void *ctx, uint8_t *buf, int len, int timeout_ms)
+{
+    UartCtx *u = ctx;
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(u->fd, &rfds);
+    struct timeval tv;
+    tv.tv_sec  = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+retry:;
+    int r = select(u->fd + 1, &rfds, NULL, NULL, &tv);
+    if (r < 0) {
+        if (errno == EINTR) {
+            FD_ZERO(&rfds);
+            FD_SET(u->fd, &rfds);
+            goto retry;
+        }
+        return TRANSPORT_ERR_IO;
+    }
+    if (r == 0) return TRANSPORT_ERR_TIMEOUT;
+
+    ssize_t n = read(u->fd, buf, (size_t)len);
+    if (n < 0)
+        return (errno == EAGAIN || errno == EINTR)
+               ? TRANSPORT_ERR_TIMEOUT : TRANSPORT_ERR_IO;
+    if (n == 0) return TRANSPORT_ERR_CLOSED;
+    return (int)n;
+}
+
+static int uart_write(void *ctx, const uint8_t *buf, int len)
+{
+    UartCtx *u = ctx;
+    ssize_t n = write(u->fd, buf, (size_t)len);
+    if (n < 0) return TRANSPORT_ERR_IO;
+    if (n == 0) return TRANSPORT_ERR_CLOSED;
+    return (int)n;
+}
+
+static void uart_close(void *ctx)
+{
+    UartCtx *u = ctx;
+    close(u->fd);
+    free(u);
+}
+
+/* ── public ──────────────────────────────────────────────────────────────── */
+
+void transport_destroy(WireTransport *t)
+{
+    if (!t) return;
+    if (t->close) t->close(t->ctx);
+    free(t);
+}
+
+WireTransport *uart_transport_open(const char *port, int baud)
+{
+    int fd = wire_serial_open(port, baud);
+    if (fd < 0) return NULL;
+
+    UartCtx *ctx = malloc(sizeof(UartCtx));
+    if (!ctx) { close(fd); return NULL; }
+    ctx->fd = fd;
+
+    WireTransport *t = malloc(sizeof(WireTransport));
+    if (!t) { close(fd); free(ctx); return NULL; }
+    t->read  = uart_read;
+    t->write = uart_write;
+    t->close = uart_close;
+    t->ctx   = ctx;
+    return t;
+}

--- a/src/uart_transport.h
+++ b/src/uart_transport.h
@@ -1,0 +1,19 @@
+/* uart_transport.h — POSIX fd wrapped as WireTransport.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef UART_TRANSPORT_H
+#define UART_TRANSPORT_H
+
+#include "transport.h"
+
+/*
+ * Open a UART or PTY and return a heap-allocated WireTransport.
+ * port  — device path, e.g. "/dev/ttyUSB0"
+ * baud  — baud rate; pass 0 for PTY / QEMU (no baud negotiation)
+ * Returns NULL on error (message printed to stderr).
+ * Caller destroys with transport_destroy().
+ */
+WireTransport *uart_transport_open(const char *port, int baud);
+
+#endif /* UART_TRANSPORT_H */

--- a/tools/69-probe-rs.rules
+++ b/tools/69-probe-rs.rules
@@ -1,0 +1,29 @@
+# udev rules for probe-rs USB debug probes.
+# Source: https://probe.rs/docs/getting-started/probe-setup/
+#
+# Install:
+#   sudo cp tools/69-probe-rs.rules /etc/udev/rules.d/
+#   sudo udevadm control --reload
+
+# ST-Link V2
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", TAG+="uaccess"
+# ST-Link V2-1 / Nucleo
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", TAG+="uaccess"
+# ST-Link V3
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374d", TAG+="uaccess"
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374e", TAG+="uaccess"
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374f", TAG+="uaccess"
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3753", TAG+="uaccess"
+
+# CMSIS-DAP / DAPLink (generic HID VID:PID varies by board)
+ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", TAG+="uaccess"
+
+# J-Link (Segger)
+ATTRS{idVendor}=="1366", ATTRS{idProduct}=="0101", TAG+="uaccess"
+ATTRS{idVendor}=="1366", ATTRS{idProduct}=="0105", TAG+="uaccess"
+ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1015", TAG+="uaccess"
+ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1051", TAG+="uaccess"
+
+# WCH-Link
+ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8010", TAG+="uaccess"
+ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8012", TAG+="uaccess"


### PR DESCRIPTION
## Summary

- **CI**: `native-host-artifacts` job (linux-x86_64, darwin-arm64) now installs stable Rust so the released binary includes probe support
- **Release**: All 4 build legs updated — native legs get `rustup install stable`; darwin-x86_64 leg adds `rustup target add x86_64-apple-darwin` for cargo cross-compile; linux-arm64 cross leg stays `MKDBG_SKIP_PROBE=ON`
- **CMakeLists**: When `CMAKE_OSX_ARCHITECTURES=x86_64`, passes `--target x86_64-apple-darwin` to cargo and reads lib from the target-specific output path
- **`mkdbg doctor`**: With `MKDBG_PROBE_SUPPORT`, reports detected probes via `probe_list()`; on Linux checks for `69-probe-rs.rules` and prints fix command if missing
- **`tools/69-probe-rs.rules`**: udev rules for ST-Link / CMSIS-DAP / J-Link / WCH-Link

## Test plan

- [ ] CI passes on ubuntu-latest (linux-x86_64, probe enabled)
- [ ] CI passes on macos-14 (darwin-arm64, probe enabled)
- [ ] `mkdbg-native --version` smoke passes on both legs
- [ ] darwin-x86_64 release leg builds clean with `--target x86_64-apple-darwin` (watch release workflow if triggered)