### PR TITLE
fix(config): off-by-one in parse_quoted_value rejects valid input

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -101,7 +101,7 @@ int parse_quoted_value(const char *value, char *out, size_t out_size)
   if (len < 2U || value[len - 1U] != '"') {
     return -1;
   }
-  if (len - 1U >= out_size) {
+  if (len - 2U >= out_size) {
     return -1;
   }
   memmove(out, value + 1, len - 2U);


### PR DESCRIPTION
The check (len - 1U >= out_size) was one too strict: a quoted string whose content exactly fills the output buffer (content + NUL == out_size) was rejected even though it fits. The correct check is (len - 2U >= out_size), since content is len-2 chars and one byte is needed for the NUL terminator.